### PR TITLE
[#5] 마니또 채팅방 생성

### DIFF
--- a/web/build.gradle
+++ b/web/build.gradle
@@ -15,6 +15,10 @@ repositories {
 	mavenCentral()
 }
 
+tasks.withType(JavaCompile) {
+	options.compilerArgs << "-parameters"
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/web/src/main/java/com/example/web/advice/GlobalExceptionHandler.java
+++ b/web/src/main/java/com/example/web/advice/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.web.advice;
 
 import com.example.web.exception.ErrorMsg;
 import com.example.web.exception.room.CanNotEnterRoomException;
+import com.example.web.exception.room.DuplicatedRoomException;
 import com.example.web.exception.room.DuplicatedUserRoomException;
 import com.example.web.exception.room.RoomNotFoundException;
 import com.example.web.exception.user.UserNotFoundException;
@@ -42,8 +43,8 @@ public class GlobalExceptionHandler {
         return createResponse(e.getMessage(), HttpStatus.FORBIDDEN);
     }
 
-    @ExceptionHandler(DuplicatedUserRoomException.class)
-    public ResponseEntity<ErrorMsg> duplicatedUserRoomException(DuplicatedUserRoomException e) {
+    @ExceptionHandler({DuplicatedUserRoomException.class, DuplicatedRoomException.class})
+    public ResponseEntity<ErrorMsg> duplicatedUserRoomException(RuntimeException e) {
         return createResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/web/src/main/java/com/example/web/controller/ManitoRoomController.java
+++ b/web/src/main/java/com/example/web/controller/ManitoRoomController.java
@@ -1,0 +1,25 @@
+package com.example.web.controller;
+
+import com.example.web.dto.*;
+import com.example.web.service.ManitoRoomService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/manito/room")
+@RequiredArgsConstructor
+public class ManitoRoomController {
+
+    private final ManitoRoomService manitoRoomService;
+
+    @PostMapping
+    public ResponseEntity<CreateManitoRoomResponse> createManitoRooms(@Valid @RequestBody CreateManitoRoomRequest dto) {
+        return new ResponseEntity<>(manitoRoomService.createManitoRooms(dto), HttpStatus.OK);
+    }
+}

--- a/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
+++ b/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -34,6 +35,7 @@ public class GroupRoomDetail {
     private Room room;
 
     @OneToMany(mappedBy = "groupRoomDetail", fetch = FetchType.LAZY)
+    @BatchSize(size = 25)
     @Setter
     @JsonManagedReference
     private List<ManitoRoomDetail> manitoRoomDetails;

--- a/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
+++ b/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
@@ -36,7 +36,7 @@ public class GroupRoomDetail {
     @OneToMany(mappedBy = "groupRoomDetail", fetch = FetchType.LAZY)
     @Setter
     @JsonManagedReference
-    private List<ManitoRoomDetail> manitoRoomDetail;
+    private List<ManitoRoomDetail> manitoRoomDetails;
 
     @Setter
     @Column(nullable = false)

--- a/web/src/main/java/com/example/web/domain/ManitoRoomDetail.java
+++ b/web/src/main/java/com/example/web/domain/ManitoRoomDetail.java
@@ -31,8 +31,7 @@ public class ManitoRoomDetail {
     private Room room;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "group_room_id")
+    @JoinColumn(name = "group_room_id", nullable = false)
     @JsonBackReference
     @JsonIgnoreProperties
     private GroupRoomDetail groupRoomDetail;

--- a/web/src/main/java/com/example/web/domain/ManitoRoomDetail.java
+++ b/web/src/main/java/com/example/web/domain/ManitoRoomDetail.java
@@ -2,25 +2,22 @@ package com.example.web.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "group_room_details")
+@Table(name = "manito_room_details")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GroupRoomDetail {
+public class ManitoRoomDetail {
 
     @Id
     @Column(name = "room_id")
@@ -33,22 +30,15 @@ public class GroupRoomDetail {
     @JsonIgnoreProperties
     private Room room;
 
-    @OneToMany(mappedBy = "groupRoomDetail", fetch = FetchType.LAZY)
-    @Setter
-    @JsonManagedReference
-    private List<ManitoRoomDetail> manitoRoomDetail;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "group_room_id")
+    @JsonBackReference
+    @JsonIgnoreProperties
+    private GroupRoomDetail groupRoomDetail;
 
-    @Setter
-    @Column(nullable = false)
-    private String roomName;
-
-    @Setter
-    @Column(nullable = false)
-    private Integer roomOwnerId;
-
-    @Setter
-    @Column(nullable = false)
-    private String enterCode;
+    @Column
+    private LocalDateTime expiresAt;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -57,7 +47,9 @@ public class GroupRoomDetail {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public GroupRoomDetail(Room room) {
+    public ManitoRoomDetail(Room room, GroupRoomDetail groupRoomDetail, LocalDateTime expiresAt) {
         this.room = room;
+        this.groupRoomDetail = groupRoomDetail;
+        this.expiresAt = expiresAt;
     }
 }

--- a/web/src/main/java/com/example/web/domain/Room.java
+++ b/web/src/main/java/com/example/web/domain/Room.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -47,6 +48,7 @@ public class Room {
     private ManitoRoomDetail manitoRoomDetail;
 
     @OneToMany(mappedBy = "room", fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     @Setter
     @JsonManagedReference
     private List<UserRoom> userRoom;

--- a/web/src/main/java/com/example/web/domain/Room.java
+++ b/web/src/main/java/com/example/web/domain/Room.java
@@ -41,6 +41,11 @@ public class Room {
     @JsonManagedReference
     private GroupRoomDetail groupRoomDetail;
 
+    @OneToOne(mappedBy = "room", fetch = FetchType.LAZY)
+    @Setter
+    @JsonManagedReference
+    private ManitoRoomDetail manitoRoomDetail;
+
     @OneToMany(mappedBy = "room", fetch = FetchType.LAZY)
     @Setter
     @JsonManagedReference

--- a/web/src/main/java/com/example/web/domain/User.java
+++ b/web/src/main/java/com/example/web/domain/User.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -35,6 +36,7 @@ public class User {
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     @Setter
     @JsonManagedReference
     private List<UserRoom> userRoom;

--- a/web/src/main/java/com/example/web/domain/UserRoom.java
+++ b/web/src/main/java/com/example/web/domain/UserRoom.java
@@ -45,11 +45,6 @@ public class UserRoom {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public UserRoom(User user, Room room) {
-        this.user = user;
-        this.room = room;
-    }
-
     public UserRoom(User user, Room room, String nickname) {
         this.user = user;
         this.room = room;

--- a/web/src/main/java/com/example/web/domain/UserRoom.java
+++ b/web/src/main/java/com/example/web/domain/UserRoom.java
@@ -23,19 +23,19 @@ public class UserRoom {
     @Column(name = "user_room_id")
     private Integer id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @JsonBackReference
     @JsonIgnoreProperties
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")
     @JsonBackReference
     @JsonIgnoreProperties
     private Room room;
 
-    @Column(nullable = false)
+    @Column
     private String nickname;
 
     @CreatedDate
@@ -44,6 +44,11 @@ public class UserRoom {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public UserRoom(User user, Room room) {
+        this.user = user;
+        this.room = room;
+    }
 
     public UserRoom(User user, Room room, String nickname) {
         this.user = user;

--- a/web/src/main/java/com/example/web/dto/CreateManitoRoomDetailsParam.java
+++ b/web/src/main/java/com/example/web/dto/CreateManitoRoomDetailsParam.java
@@ -1,0 +1,14 @@
+package com.example.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CreateManitoRoomDetailsParam {
+    private Integer groupRoomId;
+    List<Integer> roomIds;
+    private Long expiresDays;
+}

--- a/web/src/main/java/com/example/web/dto/CreateManitoRoomRequest.java
+++ b/web/src/main/java/com/example/web/dto/CreateManitoRoomRequest.java
@@ -1,0 +1,23 @@
+package com.example.web.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class CreateManitoRoomRequest {
+
+    @NotNull
+    private Integer groupRoomId;
+
+    @NotNull(message = "만료일은 반드시 입력해야 합니다.")
+    @Min(value = 1, message = "만료일은 최소 1일부터 지정 가능합니다.")
+    @Max(value = 7, message = "만료일은 최대 7일까지 지정 가능합니다.")
+    private Long expiresDays;
+}

--- a/web/src/main/java/com/example/web/dto/CreateManitoRoomResponse.java
+++ b/web/src/main/java/com/example/web/dto/CreateManitoRoomResponse.java
@@ -1,0 +1,11 @@
+package com.example.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateManitoRoomResponse {
+    private Integer groupRoomId;
+    private Integer manitoRoomCount;
+}

--- a/web/src/main/java/com/example/web/dto/CreateRoomsParam.java
+++ b/web/src/main/java/com/example/web/dto/CreateRoomsParam.java
@@ -1,0 +1,12 @@
+package com.example.web.dto;
+
+import com.example.web.enums.RoomType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateRoomsParam {
+    private RoomType type;
+    private Integer count;
+}

--- a/web/src/main/java/com/example/web/dto/CreateUserRoomsParam.java
+++ b/web/src/main/java/com/example/web/dto/CreateUserRoomsParam.java
@@ -1,0 +1,14 @@
+package com.example.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class CreateUserRoomsParam {
+    List<Integer> roomIds;
+    private Map<Integer, Integer> pairs;
+}

--- a/web/src/main/java/com/example/web/exception/room/DuplicatedRoomException.java
+++ b/web/src/main/java/com/example/web/exception/room/DuplicatedRoomException.java
@@ -1,0 +1,14 @@
+package com.example.web.exception.room;
+
+/**
+ * 이미 채팅방이 존재하는 경우
+ */
+public class DuplicatedRoomException extends RuntimeException {
+    public DuplicatedRoomException(String message) {
+        super(message);
+    }
+
+    public DuplicatedRoomException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/web/src/main/java/com/example/web/repository/GroupRoomDetailRepository.java
+++ b/web/src/main/java/com/example/web/repository/GroupRoomDetailRepository.java
@@ -1,9 +1,9 @@
 package com.example.web.repository;
 
 import com.example.web.domain.GroupRoomDetail;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.web.repository.common.BaseRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GroupRoomDetailRepository extends JpaRepository<GroupRoomDetail, Integer> {
+public interface GroupRoomDetailRepository extends BaseRepository<GroupRoomDetail, Integer> {
 }

--- a/web/src/main/java/com/example/web/repository/ManitoRoomDetailRepository.java
+++ b/web/src/main/java/com/example/web/repository/ManitoRoomDetailRepository.java
@@ -1,13 +1,13 @@
 package com.example.web.repository;
 
 import com.example.web.domain.ManitoRoomDetail;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.web.repository.common.BaseRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ManitoRoomDetailRepository extends JpaRepository<ManitoRoomDetail, Integer> {
+public interface ManitoRoomDetailRepository extends BaseRepository<ManitoRoomDetail, Integer> {
 
     @Query("SELECT count(mrd) > 0 from ManitoRoomDetail mrd where mrd.groupRoomDetail.id = :groupRoomId")
     boolean existsByGroupRoomId(@Param("groupRoomId") Integer groupRoomId);

--- a/web/src/main/java/com/example/web/repository/ManitoRoomDetailRepository.java
+++ b/web/src/main/java/com/example/web/repository/ManitoRoomDetailRepository.java
@@ -1,0 +1,14 @@
+package com.example.web.repository;
+
+import com.example.web.domain.ManitoRoomDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ManitoRoomDetailRepository extends JpaRepository<ManitoRoomDetail, Integer> {
+
+    @Query("SELECT count(mrd) > 0 from ManitoRoomDetail mrd where mrd.groupRoomDetail.id = :groupRoomId")
+    boolean existsByGroupRoomId(@Param("groupRoomId") Integer groupRoomId);
+}

--- a/web/src/main/java/com/example/web/repository/RoomRepository.java
+++ b/web/src/main/java/com/example/web/repository/RoomRepository.java
@@ -2,10 +2,10 @@ package com.example.web.repository;
 
 import com.example.web.domain.Room;
 import com.example.web.enums.RoomType;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.web.repository.common.BaseRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RoomRepository extends JpaRepository<Room, Integer> {
+public interface RoomRepository extends BaseRepository<Room, Integer> {
     boolean existsByIdAndType(Integer id, RoomType type);
 }

--- a/web/src/main/java/com/example/web/repository/UserRepository.java
+++ b/web/src/main/java/com/example/web/repository/UserRepository.java
@@ -1,9 +1,9 @@
 package com.example.web.repository;
 
 import com.example.web.domain.User;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.web.repository.common.BaseRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends BaseRepository<User, Integer> {
 }

--- a/web/src/main/java/com/example/web/repository/UserRoomRepository.java
+++ b/web/src/main/java/com/example/web/repository/UserRoomRepository.java
@@ -2,9 +2,17 @@ package com.example.web.repository;
 
 import com.example.web.domain.UserRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
+
     boolean existsByUserIdAndRoomId(Integer userId, Integer roomId);
+
+    @Query("SELECT ur.user.id FROM UserRoom ur where ur.room.id = :roomId")
+    List<Integer> findUserIdByRoomId(@Param("roomId") Integer roomId);
 }

--- a/web/src/main/java/com/example/web/repository/UserRoomRepository.java
+++ b/web/src/main/java/com/example/web/repository/UserRoomRepository.java
@@ -14,5 +14,5 @@ public interface UserRoomRepository extends BaseRepository<UserRoom, Integer> {
     boolean existsByUserIdAndRoomId(Integer userId, Integer roomId);
 
     @Query("SELECT ur.user.id FROM UserRoom ur where ur.room.id = :roomId")
-    List<Integer> findUserIdByRoomId(@Param("roomId") Integer roomId);
+    List<Integer> findUserIdsByRoomId(@Param("roomId") Integer roomId);
 }

--- a/web/src/main/java/com/example/web/repository/UserRoomRepository.java
+++ b/web/src/main/java/com/example/web/repository/UserRoomRepository.java
@@ -1,7 +1,7 @@
 package com.example.web.repository;
 
 import com.example.web.domain.UserRoom;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.web.repository.common.BaseRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
+public interface UserRoomRepository extends BaseRepository<UserRoom, Integer> {
 
     boolean existsByUserIdAndRoomId(Integer userId, Integer roomId);
 

--- a/web/src/main/java/com/example/web/repository/common/BaseRepository.java
+++ b/web/src/main/java/com/example/web/repository/common/BaseRepository.java
@@ -1,0 +1,26 @@
+package com.example.web.repository.common;
+
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@NoRepositoryBean
+public interface BaseRepository<T, ID> extends Repository<T, ID> {
+    Optional<T> findById(ID id);
+
+    <S extends T> S save(S entity);
+
+    <S extends T> List<S> saveAll(Iterable<S> entities);
+
+    void deleteById(ID id);
+
+    void delete(T entity);
+
+    void deleteAll(Iterable<? extends T> entities);
+
+    T getReferenceById(ID id);
+
+    boolean existsById(ID id);
+}

--- a/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
+++ b/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
@@ -5,7 +5,6 @@ import com.example.web.domain.Room;
 import com.example.web.repository.GroupRoomDetailRepository;
 import com.example.web.vo.GroupRoomDetailVo;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.example.web.dto.CreateGroupRoomDetailParam;
@@ -17,8 +16,7 @@ public class GroupRoomDetailService {
 
     private final GroupRoomDetailRepository groupRoomDetailRepository;
 
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final EntityManager entityManager;
 
     public GroupRoomDetailVo createGroupRoomDetail(CreateGroupRoomDetailParam param) {
         Room room = entityManager.getReference(Room.class, param.getRoomId());
@@ -28,7 +26,7 @@ public class GroupRoomDetailService {
         groupRoomDetail.setRoomOwnerId(param.getRoomOwnerId());
         groupRoomDetail.setEnterCode(param.getEnterCode());
 
-        groupRoomDetailRepository.save(groupRoomDetail);
+        groupRoomDetail = groupRoomDetailRepository.save(groupRoomDetail);
 
         return createGroupRoomDetailVo(groupRoomDetail);
     }

--- a/web/src/main/java/com/example/web/service/ManitoRoomDetailService.java
+++ b/web/src/main/java/com/example/web/service/ManitoRoomDetailService.java
@@ -6,7 +6,6 @@ import com.example.web.domain.Room;
 import com.example.web.dto.CreateManitoRoomDetailsParam;
 import com.example.web.repository.ManitoRoomDetailRepository;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,12 +20,11 @@ public class ManitoRoomDetailService {
 
     private final ManitoRoomDetailRepository manitoRoomDetailRepository;
 
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final EntityManager entityManager;
 
     public List<Integer> createManitoRoomDetails(CreateManitoRoomDetailsParam param) {
         List<ManitoRoomDetail> manitoRoomDetails = makeRoomDetailList(param);
-        manitoRoomDetailRepository.saveAll(manitoRoomDetails);
+        manitoRoomDetails = manitoRoomDetailRepository.saveAll(manitoRoomDetails);
 
         return manitoRoomDetails.stream()
                 .map(ManitoRoomDetail::getId)

--- a/web/src/main/java/com/example/web/service/ManitoRoomDetailService.java
+++ b/web/src/main/java/com/example/web/service/ManitoRoomDetailService.java
@@ -1,0 +1,51 @@
+package com.example.web.service;
+
+import com.example.web.domain.GroupRoomDetail;
+import com.example.web.domain.ManitoRoomDetail;
+import com.example.web.domain.Room;
+import com.example.web.dto.CreateManitoRoomDetailsParam;
+import com.example.web.repository.ManitoRoomDetailRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ManitoRoomDetailService {
+
+    private final ManitoRoomDetailRepository manitoRoomDetailRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public List<Integer> createManitoRoomDetails(CreateManitoRoomDetailsParam param) {
+        List<ManitoRoomDetail> manitoRoomDetails = makeRoomDetailList(param);
+        manitoRoomDetailRepository.saveAll(manitoRoomDetails);
+
+        return manitoRoomDetails.stream()
+                .map(ManitoRoomDetail::getId)
+                .collect(Collectors.toList());
+    }
+
+    private List<ManitoRoomDetail> makeRoomDetailList(CreateManitoRoomDetailsParam param) {
+        List<ManitoRoomDetail> manitoRoomDetails = new ArrayList<>();
+
+        GroupRoomDetail groupRoomDetail = entityManager.getReference(GroupRoomDetail.class, param.getGroupRoomId());
+        param.getRoomIds().forEach(roomId -> {
+            Room room = entityManager.getReference(Room.class, roomId);
+            manitoRoomDetails.add(new ManitoRoomDetail(room, groupRoomDetail, LocalDateTime.now().plusDays(param.getExpiresDays())));
+        });
+
+        return manitoRoomDetails;
+    }
+
+    public boolean isExistsManitoRoomsInGroup(Integer groupRoomId) {
+        return manitoRoomDetailRepository.existsByGroupRoomId(groupRoomId);
+    }
+}

--- a/web/src/main/java/com/example/web/service/ManitoRoomService.java
+++ b/web/src/main/java/com/example/web/service/ManitoRoomService.java
@@ -1,0 +1,83 @@
+package com.example.web.service;
+
+import com.example.web.dto.*;
+import com.example.web.enums.RoomType;
+import com.example.web.exception.room.DuplicatedRoomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class ManitoRoomService {
+
+    private final RoomService roomService;
+    private final ManitoRoomDetailService manitoRoomDetailService;
+    private final UserRoomService userRoomService;
+
+    @Transactional
+    public CreateManitoRoomResponse createManitoRooms(CreateManitoRoomRequest dto) {
+
+        // TODO: 유저 세션을 통해 요청자가 그룹 채팅방의 방장인지 확인한다.
+
+        if (manitoRoomDetailService.isExistsManitoRoomsInGroup(dto.getGroupRoomId())) {
+            throw new DuplicatedRoomException("이미 진행중인 마니또 채팅이 있습니다.");
+        }
+
+        // 그룹 채팅방의 전체 멤버 ID를 구한다.
+        List<Integer> groupRoomMembers = userRoomService.getRoomMembers(dto.getGroupRoomId());
+
+        // 멤버를 랜덤으로 1:1 매칭한다.
+        Map<Integer, Integer> pairs = makeMemberPairs(groupRoomMembers);
+
+        // 멤버 매칭 그룹별로 하나의 마니또 채팅방을 생성한다.
+        CreateRoomsParam createRoomsParam = CreateRoomsParam.builder()
+                .type(RoomType.M)
+                .count(pairs.size())
+                .build();
+        List<Integer> roomIds = roomService.createRooms(createRoomsParam);
+
+        CreateManitoRoomDetailsParam createManitoRoomDetailsParam = CreateManitoRoomDetailsParam.builder()
+                .groupRoomId(dto.getGroupRoomId())
+                .roomIds(roomIds)
+                .expiresDays(dto.getExpiresDays())
+                .build();
+        manitoRoomDetailService.createManitoRoomDetails(createManitoRoomDetailsParam);
+
+        // 채팅방과 멤버 연결 데이터를 저장한다.
+        CreateUserRoomsParam createUserRoomsParam = CreateUserRoomsParam.builder()
+                .roomIds(roomIds)
+                .pairs(pairs)
+                .build();
+        userRoomService.createUserRooms(createUserRoomsParam);
+
+        // TODO: 생성한 채팅방에 대한 event message 를 전송한다.(websocket)
+
+        return CreateManitoRoomResponse.builder()
+                .groupRoomId(dto.getGroupRoomId())
+                .manitoRoomCount(pairs.size())
+                .build();
+    }
+
+    private Map<Integer, Integer> makeMemberPairs(List<Integer> groupRoomMembers) {
+
+        Collections.shuffle(groupRoomMembers);
+
+        Map<Integer, Integer> pairs = new HashMap<>();
+
+        int roomSize = groupRoomMembers.size();
+        for (int i = 0; i < roomSize - 1; i += 2) {
+            pairs.put(groupRoomMembers.get(i), groupRoomMembers.get(i + 1));
+        }
+
+        if (roomSize % 2 == 1) {
+            // 멤버의 수가 홀수인 경우, 한 멤버가 2개의 채팅을 진행한다.
+            int random = new Random().nextInt(roomSize - 1);
+            pairs.put(groupRoomMembers.getLast(), groupRoomMembers.get(random));
+        }
+
+        return pairs;
+    }
+}

--- a/web/src/main/java/com/example/web/service/ManitoRoomService.java
+++ b/web/src/main/java/com/example/web/service/ManitoRoomService.java
@@ -27,7 +27,7 @@ public class ManitoRoomService {
         }
 
         // 그룹 채팅방의 전체 멤버 ID를 구한다.
-        List<Integer> groupRoomMembers = userRoomService.getRoomMembers(dto.getGroupRoomId());
+        List<Integer> groupRoomMembers = userRoomService.getUserIdsByRoomId(dto.getGroupRoomId());
 
         // 멤버를 랜덤으로 1:1 매칭한다.
         Map<Integer, Integer> pairs = makeMemberPairs(groupRoomMembers);

--- a/web/src/main/java/com/example/web/service/RoomService.java
+++ b/web/src/main/java/com/example/web/service/RoomService.java
@@ -1,12 +1,17 @@
 package com.example.web.service;
 
 import com.example.web.domain.Room;
+import com.example.web.dto.CreateRoomsParam;
 import com.example.web.enums.RoomType;
 import com.example.web.repository.RoomRepository;
 import com.example.web.dto.CreateRoomParam;
 import com.example.web.vo.RoomVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,23 @@ public class RoomService {
     public RoomVo createRoom(CreateRoomParam param) {
         Room room = roomRepository.save(new Room(param.getType()));
         return createRoomVo(room);
+    }
+
+    public List<Integer> createRooms(CreateRoomsParam param) {
+        List<Room> rooms = makeRoomList(param);
+        roomRepository.saveAll(rooms);
+
+        return rooms.stream()
+                .map(Room::getId)
+                .collect(Collectors.toList());
+    }
+
+    private List<Room> makeRoomList(CreateRoomsParam param) {
+        List<Room> rooms = new ArrayList<>();
+        for (int i = 0; i < param.getCount(); i++) {
+            rooms.add(new Room(param.getType()));
+        }
+        return rooms;
     }
 
     public boolean isExistsRoom(Integer roomId) {

--- a/web/src/main/java/com/example/web/service/RoomService.java
+++ b/web/src/main/java/com/example/web/service/RoomService.java
@@ -26,7 +26,7 @@ public class RoomService {
 
     public List<Integer> createRooms(CreateRoomsParam param) {
         List<Room> rooms = makeRoomList(param);
-        roomRepository.saveAll(rooms);
+        rooms = roomRepository.saveAll(rooms);
 
         return rooms.stream()
                 .map(Room::getId)

--- a/web/src/main/java/com/example/web/service/UserRoomService.java
+++ b/web/src/main/java/com/example/web/service/UserRoomService.java
@@ -3,6 +3,7 @@ package com.example.web.service;
 import com.example.web.domain.Room;
 import com.example.web.domain.User;
 import com.example.web.domain.UserRoom;
+import com.example.web.dto.CreateUserRoomsParam;
 import com.example.web.repository.UserRoomRepository;
 import com.example.web.vo.UserRoomVo;
 import jakarta.persistence.EntityManager;
@@ -10,6 +11,11 @@ import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.example.web.dto.CreateUserRoomParam;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,21 +27,49 @@ public class UserRoomService {
     private EntityManager entityManager;
 
     public UserRoomVo createUserRoom(CreateUserRoomParam param) {
-        User user = entityManager.getReference(User.class, param.getUserId());
-        Room room = entityManager.getReference(Room.class, param.getRoomId());
-
-        UserRoom userRoom = new UserRoom(
-                user,
-                room,
-                param.getNickname()
-        );
+        UserRoom userRoom = makeUserRoom(param.getUserId(), param.getRoomId(), param.getNickname());
         userRoomRepository.save(userRoom);
 
         return createUserRoomVo(userRoom);
     }
 
+    public List<Integer> createUserRooms(CreateUserRoomsParam param) {
+        List<UserRoom> userRooms = makeUserRoomList(param);
+        userRoomRepository.saveAll(userRooms);
+
+        return userRooms.stream()
+                .map(UserRoom::getId)
+                .collect(Collectors.toList());
+    }
+
+    private List<UserRoom> makeUserRoomList(CreateUserRoomsParam param) {
+        List<UserRoom> userRooms = new ArrayList<>();
+
+        AtomicInteger i = new AtomicInteger();
+        param.getPairs().forEach((firstUserId, secondUserId) -> {
+            int roomId = param.getRoomIds().get(i.get());
+            userRooms.add(makeUserRoom(firstUserId, roomId, null));
+            userRooms.add(makeUserRoom(secondUserId, roomId, null));
+
+            i.getAndIncrement();
+        });
+
+        return userRooms;
+    }
+
+    private UserRoom makeUserRoom(Integer userId, Integer roomId, String nickname) {
+        User user = entityManager.getReference(User.class, userId);
+        Room room = entityManager.getReference(Room.class, roomId);
+
+        return new UserRoom(user, room, nickname);
+    }
+
     public boolean isExistsUserRoom(Integer userId, Integer roomId) {
         return userRoomRepository.existsByUserIdAndRoomId(userId, roomId);
+    }
+
+    public List<Integer> getRoomMembers(Integer roomId) {
+        return userRoomRepository.findUserIdByRoomId(roomId);
     }
 
     private UserRoomVo createUserRoomVo(UserRoom userRoom) {

--- a/web/src/main/java/com/example/web/service/UserRoomService.java
+++ b/web/src/main/java/com/example/web/service/UserRoomService.java
@@ -7,7 +7,6 @@ import com.example.web.dto.CreateUserRoomsParam;
 import com.example.web.repository.UserRoomRepository;
 import com.example.web.vo.UserRoomVo;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.example.web.dto.CreateUserRoomParam;
@@ -23,19 +22,18 @@ public class UserRoomService {
 
     private final UserRoomRepository userRoomRepository;
 
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final EntityManager entityManager;
 
     public UserRoomVo createUserRoom(CreateUserRoomParam param) {
         UserRoom userRoom = makeUserRoom(param.getUserId(), param.getRoomId(), param.getNickname());
-        userRoomRepository.save(userRoom);
+        userRoom = userRoomRepository.save(userRoom);
 
         return createUserRoomVo(userRoom);
     }
 
     public List<Integer> createUserRooms(CreateUserRoomsParam param) {
         List<UserRoom> userRooms = makeUserRoomList(param);
-        userRoomRepository.saveAll(userRooms);
+        userRooms = userRoomRepository.saveAll(userRooms);
 
         return userRooms.stream()
                 .map(UserRoom::getId)

--- a/web/src/main/java/com/example/web/service/UserRoomService.java
+++ b/web/src/main/java/com/example/web/service/UserRoomService.java
@@ -66,8 +66,8 @@ public class UserRoomService {
         return userRoomRepository.existsByUserIdAndRoomId(userId, roomId);
     }
 
-    public List<Integer> getRoomMembers(Integer roomId) {
-        return userRoomRepository.findUserIdByRoomId(roomId);
+    public List<Integer> getUserIdsByRoomId(Integer roomId) {
+        return userRoomRepository.findUserIdsByRoomId(roomId);
     }
 
     private UserRoomVo createUserRoomVo(UserRoom userRoom) {

--- a/web/src/main/java/com/example/web/vo/GroupRoomDetailVo.java
+++ b/web/src/main/java/com/example/web/vo/GroupRoomDetailVo.java
@@ -1,26 +1,15 @@
 package com.example.web.vo;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class GroupRoomDetailVo {
     private String roomName;
     private Integer roomOwnerId;
     private String enterCode;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        GroupRoomDetailVo that = (GroupRoomDetailVo) o;
-        return Objects.equals(roomName, that.roomName) && Objects.equals(roomOwnerId, that.roomOwnerId) && Objects.equals(enterCode, that.enterCode);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(roomName, roomOwnerId, enterCode);
-    }
 }

--- a/web/src/main/java/com/example/web/vo/RoomVo.java
+++ b/web/src/main/java/com/example/web/vo/RoomVo.java
@@ -2,26 +2,15 @@ package com.example.web.vo;
 
 import com.example.web.enums.RoomType;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class RoomVo {
     private Integer id;
     private RoomType roomType;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RoomVo roomVo = (RoomVo) o;
-        return Objects.equals(id, roomVo.id) && roomType == roomVo.roomType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, roomType);
-    }
 }

--- a/web/src/main/java/com/example/web/vo/UserRoomVo.java
+++ b/web/src/main/java/com/example/web/vo/UserRoomVo.java
@@ -1,25 +1,14 @@
 package com.example.web.vo;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class UserRoomVo {
     private Integer id;
     private String nickname;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UserRoomVo that = (UserRoomVo) o;
-        return Objects.equals(id, that.id) && Objects.equals(nickname, that.nickname);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, nickname);
-    }
 }

--- a/web/src/main/java/com/example/web/vo/UserVo.java
+++ b/web/src/main/java/com/example/web/vo/UserVo.java
@@ -1,25 +1,14 @@
 package com.example.web.vo;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class UserVo {
     private Integer id;
     private String email;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UserVo userVo = (UserVo) o;
-        return Objects.equals(id, userVo.id) && Objects.equals(email, userVo.email);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, email);
-    }
 }

--- a/web/src/test/java/com/example/web/controller/ManitoRoomControllerTest.java
+++ b/web/src/test/java/com/example/web/controller/ManitoRoomControllerTest.java
@@ -1,0 +1,83 @@
+package com.example.web.controller;
+
+import com.example.web.dto.CreateManitoRoomRequest;
+import com.example.web.dto.CreateManitoRoomResponse;
+import com.example.web.service.ManitoRoomService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ManitoRoomController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class ManitoRoomControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ManitoRoomService manitoRoomService;
+
+    Integer groupRoomId = 1;
+    Long expiresDays = 1L;
+
+    @Test
+    @DisplayName("마니또 채팅방을 생성합니다.")
+    void create_manito_room() throws Exception {
+
+        // given
+        CreateManitoRoomRequest dto = getCreateManitoRoomsRequest();
+        CreateManitoRoomResponse createManitoRoomResponse = getCreateManitoRoomsResponse();
+        when(manitoRoomService.createManitoRooms(any(CreateManitoRoomRequest.class))).thenReturn(createManitoRoomResponse);
+
+        // when & then
+        mockMvc.perform(post("/manito/room")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(createManitoRoomResponse))
+        );
+    }
+
+    @Test
+    @DisplayName("마니또 채팅방을 생성에 실패합니다. : 유효성검사 실패")
+    void create_manito_room_유효성검사_실패() throws Exception {
+        // given
+        expiresDays = 8L;
+        CreateManitoRoomRequest dto = getCreateManitoRoomsRequest();
+
+        // when & then
+        mockMvc.perform(post("/manito/room")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+    }
+
+    CreateManitoRoomRequest getCreateManitoRoomsRequest() {
+        return new CreateManitoRoomRequest(groupRoomId, expiresDays);
+    }
+
+    CreateManitoRoomResponse getCreateManitoRoomsResponse() {
+        return CreateManitoRoomResponse.builder()
+                .groupRoomId(groupRoomId)
+                .manitoRoomCount(1)
+                .build();
+    }
+}

--- a/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
@@ -1,0 +1,66 @@
+package com.example.web.repository.fake;
+
+import com.example.web.domain.GroupRoomDetail;
+import com.example.web.repository.GroupRoomDetailRepository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FakeGroupRoomDetailRepository implements GroupRoomDetailRepository {
+
+    private final Map<Integer, GroupRoomDetail> database = new HashMap<>();
+    private final AtomicInteger idGenerator = new AtomicInteger();
+
+    @Override
+    public Optional<GroupRoomDetail> findById(Integer id) {
+        return Optional.ofNullable(database.get(id));
+    }
+
+    @Override
+    public <S extends GroupRoomDetail> S save(S entity) {
+        Integer id = entity.getId();
+        if (entity.getId() == null) {
+            id = idGenerator.incrementAndGet();
+        }
+        database.put(id, entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends GroupRoomDetail> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            save(entity);
+            result.add(entity);
+        }
+        return result;
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        database.remove(id);
+    }
+
+    @Override
+    public void delete(GroupRoomDetail entity) {
+        database.remove(entity.getId());
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends GroupRoomDetail> entities) {
+        for (GroupRoomDetail entity : entities) {
+            delete(entity);
+        }
+    }
+
+    @Override
+    public GroupRoomDetail getReferenceById(Integer id) {
+        return database.get(id);
+    }
+
+    @Override
+    public boolean existsById(Integer id) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getId().equals(id));
+    }
+}

--- a/web/src/test/java/com/example/web/repository/fake/FakeManitoRoomDetailRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeManitoRoomDetailRepository.java
@@ -1,0 +1,72 @@
+package com.example.web.repository.fake;
+
+import com.example.web.domain.ManitoRoomDetail;
+import com.example.web.repository.ManitoRoomDetailRepository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FakeManitoRoomDetailRepository implements ManitoRoomDetailRepository {
+
+    private final Map<Integer, ManitoRoomDetail> database = new HashMap<>();
+    private final AtomicInteger idGenerator = new AtomicInteger();
+
+    @Override
+    public Optional<ManitoRoomDetail> findById(Integer id) {
+        return Optional.ofNullable(database.get(id));
+    }
+
+    @Override
+    public <S extends ManitoRoomDetail> S save(S entity) {
+        Integer id = entity.getId();
+        if (entity.getId() == null) {
+            id = idGenerator.incrementAndGet();
+        }
+        database.put(id, entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends ManitoRoomDetail> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            save(entity);
+            result.add(entity);
+        }
+        return result;
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        database.remove(id);
+    }
+
+    @Override
+    public void delete(ManitoRoomDetail entity) {
+        database.remove(entity.getId());
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends ManitoRoomDetail> entities) {
+        for (ManitoRoomDetail entity : entities) {
+            delete(entity);
+        }
+    }
+
+    @Override
+    public ManitoRoomDetail getReferenceById(Integer id) {
+        return database.get(id);
+    }
+
+    @Override
+    public boolean existsById(Integer id) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getId().equals(id));
+    }
+
+    @Override
+    public boolean existsByGroupRoomId(Integer groupRoomId) {
+        return database.values().stream()
+                .anyMatch(mrd -> mrd.getGroupRoomDetail().getId().equals(groupRoomId));
+    }
+}

--- a/web/src/test/java/com/example/web/repository/fake/FakeRoomRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeRoomRepository.java
@@ -1,0 +1,73 @@
+package com.example.web.repository.fake;
+
+import com.example.web.domain.Room;
+import com.example.web.enums.RoomType;
+import com.example.web.repository.RoomRepository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FakeRoomRepository implements RoomRepository {
+
+    private final Map<Integer, Room> database = new HashMap<>();
+    private final AtomicInteger idGenerator = new AtomicInteger();
+
+    @Override
+    public Optional<Room> findById(Integer id) {
+        return Optional.ofNullable(database.get(id));
+    }
+
+    @Override
+    public <S extends Room> S save(S entity) {
+        Integer id = entity.getId();
+        if (entity.getId() == null) {
+            id = idGenerator.incrementAndGet();
+        }
+        database.put(id, entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends Room> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            save(entity);
+            result.add(entity);
+        }
+        return result;
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        database.remove(id);
+    }
+
+    @Override
+    public void delete(Room entity) {
+        database.remove(entity.getId());
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Room> entities) {
+        for (Room entity : entities) {
+            delete(entity);
+        }
+    }
+
+    @Override
+    public Room getReferenceById(Integer id) {
+        return database.get(id);
+    }
+
+    @Override
+    public boolean existsById(Integer id) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getId().equals(id));
+    }
+
+    @Override
+    public boolean existsByIdAndType(Integer id, RoomType type) {
+        return database.values().stream()
+                .anyMatch(r -> r.getId().equals(id) && r.getType().equals(type));
+    }
+}

--- a/web/src/test/java/com/example/web/repository/fake/FakeUserRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeUserRepository.java
@@ -1,0 +1,66 @@
+package com.example.web.repository.fake;
+
+import com.example.web.domain.User;
+import com.example.web.repository.UserRepository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FakeUserRepository implements UserRepository {
+
+    private final Map<Integer, User> database = new HashMap<>();
+    private final AtomicInteger idGenerator = new AtomicInteger();
+
+    @Override
+    public Optional<User> findById(Integer id) {
+        return Optional.ofNullable(database.get(id));
+    }
+
+    @Override
+    public <S extends User> S save(S entity) {
+        Integer id = entity.getId();
+        if (entity.getId() == null) {
+            id = idGenerator.incrementAndGet();
+        }
+        database.put(id, entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends User> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            save(entity);
+            result.add(entity);
+        }
+        return result;
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        database.remove(id);
+    }
+
+    @Override
+    public void delete(User entity) {
+        database.remove(entity.getId());
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends User> entities) {
+        for (User entity : entities) {
+            delete(entity);
+        }
+    }
+
+    @Override
+    public User getReferenceById(Integer id) {
+        return database.get(id);
+    }
+
+    @Override
+    public boolean existsById(Integer id) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getId().equals(id));
+    }
+}

--- a/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
@@ -1,0 +1,81 @@
+package com.example.web.repository.fake;
+
+import com.example.web.domain.UserRoom;
+import com.example.web.repository.UserRoomRepository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class FakeUserRoomRepository implements UserRoomRepository {
+
+    private final Map<Integer, UserRoom> database = new HashMap<>();
+    private final AtomicInteger idGenerator = new AtomicInteger();
+
+    @Override
+    public Optional<UserRoom> findById(Integer id) {
+        return Optional.ofNullable(database.get(id));
+    }
+
+    @Override
+    public List<Integer> findUserIdByRoomId(Integer roomId) {
+        return database.values().stream()
+                .filter(ur -> ur.getRoom().getId().equals(roomId))
+                .map(ur -> ur.getUser().getId())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public <S extends UserRoom> S save(S entity) {
+        Integer id = entity.getId();
+        if (entity.getId() == null) {
+            id = idGenerator.incrementAndGet();
+        }
+        database.put(id, entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends UserRoom> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            save(entity);
+            result.add(entity);
+        }
+        return result;
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        database.remove(id);
+    }
+
+    @Override
+    public void delete(UserRoom entity) {
+        database.remove(entity.getId());
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends UserRoom> entities) {
+        for (UserRoom entity : entities) {
+            delete(entity);
+        }
+    }
+
+    @Override
+    public UserRoom getReferenceById(Integer id) {
+        return database.get(id);
+    }
+
+    @Override
+    public boolean existsById(Integer id) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getId().equals(id));
+    }
+
+    @Override
+    public boolean existsByUserIdAndRoomId(Integer userId, Integer roomId) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getUser().getId().equals(userId) && ur.getRoom().getId().equals(roomId));
+    }
+}

--- a/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
@@ -18,7 +18,7 @@ public class FakeUserRoomRepository implements UserRoomRepository {
     }
 
     @Override
-    public List<Integer> findUserIdByRoomId(Integer roomId) {
+    public List<Integer> findUserIdsByRoomId(Integer roomId) {
         return database.values().stream()
                 .filter(ur -> ur.getRoom().getId().equals(roomId))
                 .map(ur -> ur.getUser().getId())

--- a/web/src/test/java/com/example/web/service/GroupRoomDetailServiceTest.java
+++ b/web/src/test/java/com/example/web/service/GroupRoomDetailServiceTest.java
@@ -1,7 +1,7 @@
 package com.example.web.service;
 
 import com.example.web.domain.Room;
-import com.example.web.repository.GroupRoomDetailRepository;
+import com.example.web.repository.fake.FakeGroupRoomDetailRepository;
 import com.example.web.vo.GroupRoomDetailVo;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Assertions;
@@ -9,13 +9,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import com.example.web.dto.CreateGroupRoomDetailParam;
-
-import java.lang.reflect.Field;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,12 +22,8 @@ import static org.mockito.Mockito.when;
 class GroupRoomDetailServiceTest {
 
     @Mock
-    private GroupRoomDetailRepository groupRoomDetailRepository;
-
-    @Mock
     private EntityManager entityManager;
 
-    @InjectMocks
     private GroupRoomDetailService groupRoomDetailService;
 
     Integer roomId = 1;
@@ -46,9 +39,9 @@ class GroupRoomDetailServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
+        groupRoomDetailService = new GroupRoomDetailService(new FakeGroupRoomDetailRepository(), entityManager);
 
         room = new Room();
-        setId(room, roomId);
     }
 
     @Test
@@ -71,11 +64,5 @@ class GroupRoomDetailServiceTest {
         // then
         Assertions.assertEquals(groupRoomDetailVo.getRoomName(), roomName);
         Assertions.assertEquals(groupRoomDetailVo.getRoomOwnerId(), roomOwnerId);
-    }
-
-    private void setId(Room room, Integer id) throws Exception {
-        Field idField = Room.class.getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(room, id);
     }
 }

--- a/web/src/test/java/com/example/web/service/ManitoRoomDetailServiceTest.java
+++ b/web/src/test/java/com/example/web/service/ManitoRoomDetailServiceTest.java
@@ -1,14 +1,13 @@
 package com.example.web.service;
 
 import com.example.web.dto.CreateManitoRoomDetailsParam;
-import com.example.web.repository.ManitoRoomDetailRepository;
+import com.example.web.repository.fake.FakeManitoRoomDetailRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,12 +19,8 @@ import java.util.List;
 class ManitoRoomDetailServiceTest {
 
     @Mock
-    private ManitoRoomDetailRepository manitoRoomDetailRepository;
-
-    @Mock
     private EntityManager entityManager;
 
-    @InjectMocks
     private ManitoRoomDetailService manitoRoomDetailService;
 
     Integer groupRoomId = 1;
@@ -33,6 +28,7 @@ class ManitoRoomDetailServiceTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        manitoRoomDetailService = new ManitoRoomDetailService(new FakeManitoRoomDetailRepository(), entityManager);
     }
 
     @Test

--- a/web/src/test/java/com/example/web/service/ManitoRoomDetailServiceTest.java
+++ b/web/src/test/java/com/example/web/service/ManitoRoomDetailServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.web.service;
+
+import com.example.web.dto.CreateManitoRoomDetailsParam;
+import com.example.web.repository.ManitoRoomDetailRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class ManitoRoomDetailServiceTest {
+
+    @Mock
+    private ManitoRoomDetailRepository manitoRoomDetailRepository;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private ManitoRoomDetailService manitoRoomDetailService;
+
+    Integer groupRoomId = 1;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("전체 마니또 채팅방의 상세정보를 저장합니다.")
+    void create_manito_room_details() {
+
+        //given
+        int count = 4;
+
+        List<Integer> roomIds = new ArrayList<>();
+        for (int i = 1; i < count + 1; i++) {
+            roomIds.add(i);
+        }
+
+        CreateManitoRoomDetailsParam createManitoRoomDetailsParam = CreateManitoRoomDetailsParam.builder()
+                .groupRoomId(groupRoomId)
+                .roomIds(roomIds)
+                .expiresDays(1L)
+                .build();
+
+        // when
+        List<Integer> manitoRoomIds = manitoRoomDetailService.createManitoRoomDetails(createManitoRoomDetailsParam);
+
+        // then
+        Assertions.assertEquals(manitoRoomIds.size(), count);
+    }
+}

--- a/web/src/test/java/com/example/web/service/ManitoRoomServiceTest.java
+++ b/web/src/test/java/com/example/web/service/ManitoRoomServiceTest.java
@@ -1,0 +1,85 @@
+package com.example.web.service;
+
+import com.example.web.dto.*;
+import com.example.web.exception.room.DuplicatedRoomException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class ManitoRoomServiceTest {
+
+    @Mock
+    private RoomService roomService;
+
+    @Mock
+    private ManitoRoomDetailService manitoRoomDetailService;
+
+    @Mock
+    private UserRoomService userRoomService;
+
+    @InjectMocks
+    private ManitoRoomService manitoRoomService;
+
+    Integer groupRoomId = 1;
+    Long expiresDays = 1L;
+
+    @Test
+    @DisplayName("새로운 마니또 채팅방들을 생성합니다.")
+    void create_manito_rooms() {
+
+        // given
+        when(manitoRoomDetailService.isExistsManitoRoomsInGroup(any())).thenReturn(false);
+
+        int memberSize = 11;
+        List<Integer> groupRoomMembers = new ArrayList<>();
+        for (int i = 1; i < memberSize + 1; i++) {
+            groupRoomMembers.add(i);
+        }
+        when(userRoomService.getRoomMembers(any())).thenReturn(groupRoomMembers);
+
+        int roomSize = (memberSize / 2) + (memberSize % 2);
+        List<Integer> roomIds = new ArrayList<>();
+        for (int i = 1; i < roomSize + 1; i++) {
+            roomIds.add(i);
+        }
+        when(roomService.createRooms(any())).thenReturn(roomIds);
+
+        // when
+        CreateManitoRoomResponse createManitoRoomResponse = manitoRoomService.createManitoRooms(getCreateManitoRoomsRequest());
+
+        // then
+        Assertions.assertEquals(createManitoRoomResponse.getGroupRoomId(), groupRoomId);
+        Assertions.assertEquals(createManitoRoomResponse.getManitoRoomCount(), roomSize);
+    }
+
+    @Test
+    @DisplayName("마니또 채팅방 생성에 실패합니다. - 이미 진행중인 마니또 채팅 존재")
+    void create_manito_rooms_이미_진행중인_마니또_채팅_존재() {
+
+        //given
+        when(manitoRoomDetailService.isExistsManitoRoomsInGroup(any())).thenReturn(true);
+
+        //when & then
+        Assertions.assertThrows(DuplicatedRoomException.class, () -> {
+            manitoRoomService.createManitoRooms(getCreateManitoRoomsRequest());
+        });
+    }
+
+    CreateManitoRoomRequest getCreateManitoRoomsRequest() {
+        return new CreateManitoRoomRequest(
+                groupRoomId,
+                expiresDays
+        );
+    }
+}

--- a/web/src/test/java/com/example/web/service/ManitoRoomServiceTest.java
+++ b/web/src/test/java/com/example/web/service/ManitoRoomServiceTest.java
@@ -46,7 +46,7 @@ class ManitoRoomServiceTest {
         for (int i = 1; i < memberSize + 1; i++) {
             groupRoomMembers.add(i);
         }
-        when(userRoomService.getRoomMembers(any())).thenReturn(groupRoomMembers);
+        when(userRoomService.getUserIdsByRoomId(any())).thenReturn(groupRoomMembers);
 
         int roomSize = (memberSize / 2) + (memberSize % 2);
         List<Integer> roomIds = new ArrayList<>();

--- a/web/src/test/java/com/example/web/service/RoomServiceTest.java
+++ b/web/src/test/java/com/example/web/service/RoomServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.web.service;
 
 import com.example.web.domain.Room;
+import com.example.web.dto.CreateRoomsParam;
 import com.example.web.enums.RoomType;
 import com.example.web.repository.RoomRepository;
 import com.example.web.dto.CreateRoomParam;
@@ -14,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -50,6 +53,32 @@ class RoomServiceTest {
 
         // then
         Assertions.assertEquals(roomVo.getId(), roomId);
+    }
+
+    @Test
+    @DisplayName("채팅방 여러개를 한번에 생성합니다.")
+    void create_rooms() {
+
+        // given
+        int count = 4;
+
+        CreateRoomsParam createRoomsParam = CreateRoomsParam.builder()
+                .type(RoomType.M)
+                .count(count)
+                .build();
+
+        List<Room> rooms = new ArrayList<>();
+        for (int i=0; i < count; i++) {
+            Room room = new Room(RoomType.M);
+            rooms.add(room);
+        }
+        when(roomRepository.saveAll(any())).thenReturn(rooms);
+
+        // when
+        List<Integer> roomIds = roomService.createRooms(createRoomsParam);
+
+        // then
+        Assertions.assertEquals(roomIds.size(), count);
     }
 
     private void setId(Room room, Integer id) throws Exception {

--- a/web/src/test/java/com/example/web/service/RoomServiceTest.java
+++ b/web/src/test/java/com/example/web/service/RoomServiceTest.java
@@ -1,43 +1,26 @@
 package com.example.web.service;
 
-import com.example.web.domain.Room;
 import com.example.web.dto.CreateRoomsParam;
 import com.example.web.enums.RoomType;
-import com.example.web.repository.RoomRepository;
 import com.example.web.dto.CreateRoomParam;
+import com.example.web.repository.fake.FakeRoomRepository;
 import com.example.web.vo.RoomVo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RoomServiceTest {
 
-    @Mock
-    private RoomRepository roomRepository;
-
-    @InjectMocks
     private RoomService roomService;
-
-    Integer roomId = 1;
-
-    Room room;
 
     @BeforeEach
     public void setUp() throws Exception {
-        room = new Room();
-        setId(room, roomId);
+        roomService = new RoomService(new FakeRoomRepository());
     }
 
     @Test
@@ -45,14 +28,14 @@ class RoomServiceTest {
     void create_room() {
 
         // given
-        CreateRoomParam createRoomParam = CreateRoomParam.builder().type(RoomType.G).build();
-        when(roomRepository.save(any(Room.class))).thenReturn(room);
+        RoomType roomType = RoomType.G;
+        CreateRoomParam createRoomParam = CreateRoomParam.builder().type(roomType).build();
 
         // when
         RoomVo roomVo = roomService.createRoom(createRoomParam);
 
         // then
-        Assertions.assertEquals(roomVo.getId(), roomId);
+        Assertions.assertEquals(roomVo.getRoomType(), roomType);
     }
 
     @Test
@@ -67,23 +50,10 @@ class RoomServiceTest {
                 .count(count)
                 .build();
 
-        List<Room> rooms = new ArrayList<>();
-        for (int i=0; i < count; i++) {
-            Room room = new Room(RoomType.M);
-            rooms.add(room);
-        }
-        when(roomRepository.saveAll(any())).thenReturn(rooms);
-
         // when
         List<Integer> roomIds = roomService.createRooms(createRoomsParam);
 
         // then
         Assertions.assertEquals(roomIds.size(), count);
-    }
-
-    private void setId(Room room, Integer id) throws Exception {
-        Field idField = Room.class.getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(room, id);
     }
 }

--- a/web/src/test/java/com/example/web/service/UserRoomServiceTest.java
+++ b/web/src/test/java/com/example/web/service/UserRoomServiceTest.java
@@ -2,6 +2,7 @@ package com.example.web.service;
 
 import com.example.web.domain.Room;
 import com.example.web.domain.User;
+import com.example.web.dto.CreateUserRoomsParam;
 import com.example.web.repository.UserRoomRepository;
 import com.example.web.dto.CreateUserRoomParam;
 import com.example.web.vo.UserRoomVo;
@@ -16,6 +17,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -72,6 +77,32 @@ class UserRoomServiceTest {
 
         // then
         Assertions.assertEquals(userRoomVo.getNickname(), nickname);
+    }
+
+    @Test
+    @DisplayName("여러 사용자-채팅방 관계를 한번에 생성합니다.")
+    void createUserRooms() {
+        // given
+        int count = 4;
+
+        List<Integer> roomIds = new ArrayList<>();
+        Map<Integer, Integer> pairs = new HashMap<>();
+        for (int i = 1; i < count + 1; i++) {
+            roomIds.add(i);
+            pairs.put(i, i + 1);
+        }
+
+        CreateUserRoomsParam createUserRoomsParam = CreateUserRoomsParam.builder()
+                .roomIds(roomIds)
+                .pairs(pairs)
+                .build();
+
+        // when
+        List<Integer> userRoomIds = userRoomService.createUserRooms(createUserRoomsParam);
+        System.out.println(userRoomIds);
+
+        // then
+        Assertions.assertEquals(userRoomIds.size(), count * 2);
     }
 
     private void setUserId(User user, Integer id) throws Exception {

--- a/web/src/test/java/com/example/web/service/UserRoomServiceTest.java
+++ b/web/src/test/java/com/example/web/service/UserRoomServiceTest.java
@@ -3,7 +3,7 @@ package com.example.web.service;
 import com.example.web.domain.Room;
 import com.example.web.domain.User;
 import com.example.web.dto.CreateUserRoomsParam;
-import com.example.web.repository.UserRoomRepository;
+import com.example.web.repository.fake.FakeUserRoomRepository;
 import com.example.web.dto.CreateUserRoomParam;
 import com.example.web.vo.UserRoomVo;
 import jakarta.persistence.EntityManager;
@@ -12,11 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,12 +28,8 @@ import static org.mockito.Mockito.when;
 class UserRoomServiceTest {
 
     @Mock
-    private UserRoomRepository userRoomRepository;
-
-    @Mock
     private EntityManager entityManager;
 
-    @InjectMocks
     private UserRoomService userRoomService;
 
     Integer userId = 1;
@@ -51,12 +45,10 @@ class UserRoomServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
+        userRoomService = new UserRoomService(new FakeUserRoomRepository(), entityManager);
 
         user = new User();
-        setUserId(user, userId);
-
         room = new Room();
-        setRoomId(room, roomId);
     }
 
     @Test
@@ -99,21 +91,8 @@ class UserRoomServiceTest {
 
         // when
         List<Integer> userRoomIds = userRoomService.createUserRooms(createUserRoomsParam);
-        System.out.println(userRoomIds);
 
         // then
         Assertions.assertEquals(userRoomIds.size(), count * 2);
-    }
-
-    private void setUserId(User user, Integer id) throws Exception {
-        Field idField = User.class.getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(user, id);
-    }
-
-    private void setRoomId(Room room, Integer id) throws Exception {
-        Field idField = Room.class.getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(room, id);
     }
 }


### PR DESCRIPTION
<br/>

## 작업 내용 📝

( 관련 이슈 : resolved  #5 )

마니또 채팅방을 생성을 요청하는 API 개발 작업입니다.

- 그룹 채팅방 멤버 1:1 랜덤 매칭
- room, manito_room_detail, user_rooms 데이터 insert
- (추후 TODO) 유저 세션 정보로 방장 확인, 생성한 채팅방 소켓 event 전송
    - 로그인 기능과 웹소켓 기능 개발 후 추가 예정입니다.

<br/>

## 테스트 ✓

- Controller: ManitoRoomControllerTest
- Service: ManitoRoomServiceTest, ManitoRoomDetailServiceTest, RoomServiceTest, UserRoomServiceTest

- API 호출 테스트
  ```cURL
  curl --location '{host}/manito/room' \
  --header 'Content-Type: application/json' \
  --data '{
      "groupRoomId": 26,
      "expiresDays": 1
  }'
  ```

<br/>
