### PR TITLE
[#6] 웹소켓 모듈 세팅

### DIFF
--- a/websocket/build.gradle
+++ b/websocket/build.gradle
@@ -1,26 +1,9 @@
-plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.0'
-	id 'io.spring.dependency-management' version '1.1.5'
-}
-
-group = 'com.example'
-version = '0.0.1-SNAPSHOT'
-
-java {
-	sourceCompatibility = '21'
-}
-
-repositories {
-	mavenCentral()
-}
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }

--- a/websocket/src/main/java/com/example/websocket/config/RedisConfig.java
+++ b/websocket/src/main/java/com/example/websocket/config/RedisConfig.java
@@ -1,0 +1,58 @@
+package com.example.websocket.config;
+
+import com.example.websocket.constant.WebSocketConstant;
+import com.example.websocket.service.RedisMessageSubscriber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.database}")
+    private int redisDatabase;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(redisPort);
+        redisStandaloneConfiguration.setDatabase(redisDatabase);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+    @Bean
+    RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory,
+                                                                MessageListenerAdapter listenerAdapter) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(listenerAdapter, new PatternTopic(WebSocketConstant.ROOM_PREFIX + "/*"));
+        return container;
+    }
+
+    @Bean
+    MessageListenerAdapter listenerAdapter(RedisMessageSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+}

--- a/websocket/src/main/java/com/example/websocket/config/WebSocketConfig.java
+++ b/websocket/src/main/java/com/example/websocket/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.example.websocket.config;
+
+import com.example.websocket.constant.WebSocketConstant;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/" + WebSocketConstant.ROOM_PREFIX);
+    }
+}

--- a/websocket/src/main/java/com/example/websocket/constant/WebSocketConstant.java
+++ b/websocket/src/main/java/com/example/websocket/constant/WebSocketConstant.java
@@ -1,0 +1,5 @@
+package com.example.websocket.constant;
+
+public class WebSocketConstant {
+    public static final String ROOM_PREFIX = "room";
+}

--- a/websocket/src/main/java/com/example/websocket/service/RedisMessageSubscriber.java
+++ b/websocket/src/main/java/com/example/websocket/service/RedisMessageSubscriber.java
@@ -1,0 +1,24 @@
+package com.example.websocket.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisMessageSubscriber implements MessageListener {
+
+    private final WebSocketMessageBroadcaster messageBroadcaster;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String messageBody = new String(message.getBody());
+        String channel = new String(message.getChannel());
+
+        // TODO: 로깅 작업을 추가합니다.
+        System.out.println("channel: " + channel + " message: " + messageBody);
+
+        messageBroadcaster.broadcast(channel, messageBody);
+    }
+}

--- a/websocket/src/main/java/com/example/websocket/service/WebSocketMessageBroadcaster.java
+++ b/websocket/src/main/java/com/example/websocket/service/WebSocketMessageBroadcaster.java
@@ -1,0 +1,16 @@
+package com.example.websocket.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WebSocketMessageBroadcaster {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void broadcast(String channel, String message) {
+        messagingTemplate.convertAndSend("/" + channel, message);
+    }
+}

--- a/websocket/src/main/resources/application.properties
+++ b/websocket/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=websocket
+server.port=${WEBSOCKET_SERVER_PORT:8081}
+
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.database=${REDIS_SCHEMA:0}

--- a/websocket/src/main/resources/static/client.html
+++ b/websocket/src/main/resources/static/client.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WebSocket Client</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <script>
+        var stompClient = "http://localhost:8080";
+        var roomId = 1;
+
+        function connect() {
+            var socket = new SockJS('/ws');
+            stompClient = Stomp.over(socket);
+            stompClient.connect({}, function (frame) {
+                console.log('Connected: ' + frame);
+                stompClient.subscribe('/room/' + roomId, function (message) {
+                    showMessage(message.body);
+                });
+            });
+        }
+
+        function disconnect() {
+            if (stompClient !== null) {
+                stompClient.disconnect();
+            }
+            console.log("Disconnected");
+        }
+
+        function showMessage(message) {
+            var response = document.getElementById("response");
+            var p = document.createElement("p");
+            p.style.wordWrap = "break-word";
+            p.appendChild(document.createTextNode(message));
+            response.appendChild(p);
+        }
+
+        window.onload = function() {
+            connect();
+        };
+    </script>
+</head>
+<body>
+<h2>WebSocket Client</h2>
+<div>
+    <button onclick="disconnect()">Disconnect</button>
+</div>
+<h3>~ Messages ~</h3>
+<div id="response"></div>
+</body>
+</html>


### PR DESCRIPTION
<br/>

## 작업 내용 📝

( 관련 이슈 : resolved  #6 )

웹소켓 모듈을 세팅하는 작업입니다.
- 필요 의존성 추가
- redis 연결 설정 및 구독 클래스 추가
- 웹소켓 연결 설정 및 브로드캐스트 클래스 추가
- 채널 규칙 (room)에 따른 상수 추가
- 테스트 클라이언트 페이지 추가

<br/>

## 테스트 ✓

(로컬 환경에서 redis 서버 설치 및 실행하거나
resources/application.properties 의 환경변수 변경 후 테스트 가능합니다.)

- WebsocketApplication 실행 (실행 시 http://localhost:6379 redis의 `room/*` 채널 구독 시작)
- http://localhost:8081/client.html 접속 
- 로컬 레디스 서버의 커맨드에서(redis-cli 또는 클라이언트 프로그램 사용) 메시지 publish : `publish room/1 "message"`
- 클라이언트 화면에 메시지 출력 확인

<br/>
