### PR TITLE
[#8] 그룹 채팅방 종료

### DIFF
--- a/web/build.gradle
+++ b/web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.retry:spring-retry:2.0.6'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/web/src/main/java/com/example/web/WebApplication.java
+++ b/web/src/main/java/com/example/web/WebApplication.java
@@ -6,10 +6,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableMongoAuditing
+@EnableRetry
+@EnableAsync
 @Import(PropertyConfig.class)
 public class WebApplication {
 

--- a/web/src/main/java/com/example/web/advice/GlobalExceptionHandler.java
+++ b/web/src/main/java/com/example/web/advice/GlobalExceptionHandler.java
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
         return createResponse(e.getMessage(), HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler({CanNotEnterRoomException.class, CanNotSendMessageException.class})
+    @ExceptionHandler({CanNotEnterRoomException.class, CanNotSendMessageException.class, CanNotDeleteRoomException.class})
     public ResponseEntity<ErrorMsg> canNotEnterRoomException(RuntimeException e) {
         return createResponse(e.getMessage(), HttpStatus.FORBIDDEN);
     }
@@ -45,7 +45,7 @@ public class GlobalExceptionHandler {
         return createResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(FailSendMessageException.class)
+    @ExceptionHandler({FailSendMessageException.class, FailDeleteRoomException.class})
     public ResponseEntity<ErrorMsg> failSendMessageException(RuntimeException e) {
         return createResponse(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/web/src/main/java/com/example/web/config/JpaConfig.java
+++ b/web/src/main/java/com/example/web/config/JpaConfig.java
@@ -1,0 +1,16 @@
+package com.example.web.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.JpaTransactionManager;
+
+@Configuration
+public class JpaConfig {
+    @Primary
+    @Bean
+    public JpaTransactionManager transactionManager(EntityManagerFactory jpaEntityManagerFactory) {
+        return new JpaTransactionManager(jpaEntityManagerFactory);
+    }
+}

--- a/web/src/main/java/com/example/web/config/MongoConfig.java
+++ b/web/src/main/java/com/example/web/config/MongoConfig.java
@@ -7,8 +7,8 @@ import org.springframework.data.mongodb.MongoTransactionManager;
 
 @Configuration
 public class MongoConfig {
-    @Bean
-    public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+    @Bean(name = "mongoTransactionManager")
+    public MongoTransactionManager mongoTransactionManager(MongoDatabaseFactory dbFactory) {
         return new MongoTransactionManager(dbFactory);
     }
 }

--- a/web/src/main/java/com/example/web/controller/GroupRoomController.java
+++ b/web/src/main/java/com/example/web/controller/GroupRoomController.java
@@ -1,18 +1,12 @@
 package com.example.web.controller;
 
-import com.example.web.dto.CreateGroupRoomRequest;
-import com.example.web.dto.EnterGroupRoomRequest;
-import com.example.web.dto.EnterRoomResponse;
+import com.example.web.dto.*;
 import com.example.web.service.GroupRoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import com.example.web.dto.CreateGroupRoomResponse;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/group/room")
@@ -29,5 +23,10 @@ public class GroupRoomController {
     @PostMapping("/enter")
     public ResponseEntity<EnterRoomResponse> enterGroupRoom(@Valid @RequestBody EnterGroupRoomRequest dto) {
         return new ResponseEntity<>(groupRoomService.enterGroupRoom(dto), HttpStatus.OK);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<EndRoomResponse> endGroupRoom(@Valid @RequestBody EndGroupRoomRequest dto) {
+        return new ResponseEntity<>(groupRoomService.endGroupRoom(dto), HttpStatus.OK);
     }
 }

--- a/web/src/main/java/com/example/web/domain/FailedRoomEvent.java
+++ b/web/src/main/java/com/example/web/domain/FailedRoomEvent.java
@@ -1,0 +1,29 @@
+package com.example.web.domain;
+
+import com.example.web.vo.RoomEventVo;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document(collection = "failed_events")
+@Getter
+public class FailedRoomEvent {
+
+    @Id
+    private String id;
+
+    private final Integer roomId;
+
+    private final RoomEventVo roomEventVo;
+
+    public FailedRoomEvent(Integer roomId, RoomEventVo roomEventVo) {
+        this.roomId = roomId;
+        this.roomEventVo = roomEventVo;
+    }
+
+    @CreatedDate
+    private LocalDateTime timestamp;
+}

--- a/web/src/main/java/com/example/web/domain/Room.java
+++ b/web/src/main/java/com/example/web/domain/Room.java
@@ -53,6 +53,9 @@ public class Room {
     @JsonManagedReference
     private List<UserRoom> userRoom;
 
+    @Setter
+    private boolean deleted = Boolean.FALSE;
+
     public Room(RoomType type) {
         this.type = type;
     }

--- a/web/src/main/java/com/example/web/dto/EndGroupRoomRequest.java
+++ b/web/src/main/java/com/example/web/dto/EndGroupRoomRequest.java
@@ -1,0 +1,19 @@
+package com.example.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class EndGroupRoomRequest {
+
+    @NotNull
+    private Integer roomId;
+
+    @NotNull
+    private Integer roomOwnerId;
+}

--- a/web/src/main/java/com/example/web/dto/EndRoomResponse.java
+++ b/web/src/main/java/com/example/web/dto/EndRoomResponse.java
@@ -1,0 +1,10 @@
+package com.example.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EndRoomResponse {
+    private Integer roomId;
+}

--- a/web/src/main/java/com/example/web/enums/EventType.java
+++ b/web/src/main/java/com/example/web/enums/EventType.java
@@ -1,0 +1,13 @@
+package com.example.web.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EventType {
+    MESSAGE("메시지 발신"),
+    END_ROOM("채팅 종료");
+
+    private final String description;
+}

--- a/web/src/main/java/com/example/web/event/PublishEventListener.java
+++ b/web/src/main/java/com/example/web/event/PublishEventListener.java
@@ -1,0 +1,56 @@
+package com.example.web.event;
+
+import com.example.web.domain.FailedRoomEvent;
+import com.example.web.repository.FailedEventRepository;
+import com.example.web.service.MessagePublisher;
+import com.example.web.vo.RoomEventVo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PublishEventListener {
+
+    private final MessagePublisher messagePublisher;
+
+    private final FailedEventRepository failedEventRepository;
+
+    @Value("${room.channel.prefix}")
+    String channelPrefix;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    @Retryable(
+            backoff = @Backoff(delay = 1000),
+            recover = "saveFailedPublishEvent"
+    )
+    public void handleRoomEndEvent(RoomEventVo roomEventVo) {
+        messagePublisher.publish(
+                channelPrefix + "/" + roomEventVo.getRoomId(),
+                roomEventVo
+        );
+    }
+
+    @Recover
+    private void saveFailedPublishEvent(RoomEventVo roomEventVo) {
+        try {
+            // 실패 작업 DB 저장
+            FailedRoomEvent failedRoomEvent = new FailedRoomEvent(
+                    roomEventVo.getRoomId(),
+                    roomEventVo
+            );
+            failedEventRepository.save(failedRoomEvent);
+        } catch (RuntimeException e) {
+            // TODO: 로깅 + 알림 처리
+            System.out.println("fail publish event");
+        }
+    }
+}
+

--- a/web/src/main/java/com/example/web/exception/room/CanNotDeleteRoomException.java
+++ b/web/src/main/java/com/example/web/exception/room/CanNotDeleteRoomException.java
@@ -1,0 +1,14 @@
+package com.example.web.exception.room;
+
+/**
+ * 채팅방을 삭제할 수 없는 경우
+ */
+public class CanNotDeleteRoomException extends RuntimeException {
+    public CanNotDeleteRoomException(String message) {
+        super(message);
+    }
+
+    public CanNotDeleteRoomException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/web/src/main/java/com/example/web/exception/room/FailDeleteRoomException.java
+++ b/web/src/main/java/com/example/web/exception/room/FailDeleteRoomException.java
@@ -1,0 +1,14 @@
+package com.example.web.exception.room;
+
+/**
+ * 채팅방 삭제에 실패한 경우
+ */
+public class FailDeleteRoomException extends RuntimeException {
+    public FailDeleteRoomException(String message) {
+        super(message);
+    }
+
+    public FailDeleteRoomException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/web/src/main/java/com/example/web/repository/FailedEventRepository.java
+++ b/web/src/main/java/com/example/web/repository/FailedEventRepository.java
@@ -1,0 +1,7 @@
+package com.example.web.repository;
+
+import com.example.web.domain.FailedRoomEvent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface FailedEventRepository extends MongoRepository<FailedRoomEvent, String> {
+}

--- a/web/src/main/java/com/example/web/repository/GroupRoomDetailRepository.java
+++ b/web/src/main/java/com/example/web/repository/GroupRoomDetailRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupRoomDetailRepository extends BaseRepository<GroupRoomDetail, Integer> {
+    boolean existsByIdAndRoomOwnerId(Integer roomId, Integer userId);
 }

--- a/web/src/main/java/com/example/web/repository/MessageRepository.java
+++ b/web/src/main/java/com/example/web/repository/MessageRepository.java
@@ -4,4 +4,5 @@ import com.example.web.domain.Message;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface MessageRepository extends MongoRepository<Message, String> {
+    void deleteByRoomId(Integer roomId);
 }

--- a/web/src/main/java/com/example/web/repository/MessageRepository.java
+++ b/web/src/main/java/com/example/web/repository/MessageRepository.java
@@ -4,5 +4,4 @@ import com.example.web.domain.Message;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface MessageRepository extends MongoRepository<Message, String> {
-    void deleteByRoomId(Integer roomId);
 }

--- a/web/src/main/java/com/example/web/repository/UserRoomRepository.java
+++ b/web/src/main/java/com/example/web/repository/UserRoomRepository.java
@@ -15,4 +15,6 @@ public interface UserRoomRepository extends BaseRepository<UserRoom, Integer> {
 
     @Query("SELECT ur.user.id FROM UserRoom ur where ur.room.id = :roomId")
     List<Integer> findUserIdsByRoomId(@Param("roomId") Integer roomId);
+
+    void deleteByRoomId(Integer roomId);
 }

--- a/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
+++ b/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
@@ -37,11 +37,19 @@ public class GroupRoomDetailService {
                 groupRoomDetail.get().getEnterCode().equals(enterCode);
     }
 
+    public boolean isRoomOwner(Integer roomId, Integer userId) {
+        return groupRoomDetailRepository.existsByIdAndRoomOwnerId(roomId, userId);
+    }
+
     private GroupRoomDetailVo createGroupRoomDetailVo(GroupRoomDetail groupRoomDetail) {
         return new GroupRoomDetailVo(
                 groupRoomDetail.getRoomName(),
                 groupRoomDetail.getRoomOwnerId(),
                 groupRoomDetail.getEnterCode()
         );
+    }
+
+    public void deleteByRoomId(Integer roomId) {
+        groupRoomDetailRepository.deleteById(roomId);
     }
 }

--- a/web/src/main/java/com/example/web/service/GroupRoomService.java
+++ b/web/src/main/java/com/example/web/service/GroupRoomService.java
@@ -2,15 +2,15 @@ package com.example.web.service;
 
 import com.example.web.dto.*;
 import com.example.web.enums.RoomType;
-import com.example.web.exception.room.CanNotEnterRoomException;
-import com.example.web.exception.room.DuplicatedUserRoomException;
-import com.example.web.exception.room.RoomNotFoundException;
+import com.example.web.exception.room.*;
 import com.example.web.exception.user.UserNotFoundException;
 import com.example.web.dto.CreateRoomParam;
+import com.example.web.vo.EndRoomEventVo;
 import com.example.web.vo.GroupRoomDetailVo;
 import com.example.web.vo.RoomVo;
 import com.example.web.vo.UserRoomVo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.example.web.dto.CreateGroupRoomDetailParam;
@@ -24,6 +24,8 @@ public class GroupRoomService {
     private final GroupRoomDetailService groupRoomDetailService;
     private final UserService userService;
     private final UserRoomService userRoomService;
+    private final ManitoRoomDetailService manitoRoomDetailService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public CreateGroupRoomResponse createGroupRoom(CreateGroupRoomRequest dto) {
@@ -83,5 +85,38 @@ public class GroupRoomService {
                 .userRoomId(userRoomVo.getId())
                 .nickname(userRoomVo.getNickname())
                 .build();
+    }
+
+    @Transactional
+    public EndRoomResponse endGroupRoom(EndGroupRoomRequest dto) {
+
+        if (!roomService.isExistsRoom(dto.getRoomId()) ||
+                !roomService.isGroupRoom(dto.getRoomId())) {
+            throw new RoomNotFoundException("그룹 채팅방이 존재하지 않습니다.");
+        }
+
+        if (!groupRoomDetailService.isRoomOwner(dto.getRoomId(), dto.getRoomOwnerId())) {
+            throw new CanNotDeleteRoomException("그룹 채팅 종료 권한이 없습니다.");
+        }
+
+        if (manitoRoomDetailService.isExistsManitoRoomsInGroup(dto.getRoomId())) {
+            throw new CanNotDeleteRoomException("마니또 채팅이 진행중일 때는 그룹 채팅을 종료할 수 없습니다.");
+        }
+
+        try {
+            // 채팅방에 속한 유저 데이터를 삭제합니다.
+            userRoomService.deleteByRoomId(dto.getRoomId());
+
+            // 채팅방 데이터를 삭제합니다.
+            groupRoomDetailService.deleteByRoomId(dto.getRoomId());
+            roomService.softDeleteById(dto.getRoomId());
+
+            applicationEventPublisher.publishEvent(new EndRoomEventVo(dto.getRoomId()));
+            return EndRoomResponse.builder()
+                    .roomId(dto.getRoomId())
+                    .build();
+        } catch (RuntimeException e) {
+            throw new FailDeleteRoomException("채팅방 삭제에 실패하였습니다.");
+        }
     }
 }

--- a/web/src/main/java/com/example/web/service/MessageService.java
+++ b/web/src/main/java/com/example/web/service/MessageService.java
@@ -84,4 +84,8 @@ public class MessageService {
                 messageVo
         );
     }
+
+    public void deleteRoomMessages(Integer roomId) {
+        messageRepository.deleteByRoomId(roomId);
+    }
 }

--- a/web/src/main/java/com/example/web/service/RedisMessagePublisher.java
+++ b/web/src/main/java/com/example/web/service/RedisMessagePublisher.java
@@ -16,7 +16,6 @@ public class RedisMessagePublisher implements MessagePublisher {
 
     @Override
     public void publish(String channel, Object message) {
-        // TODO: 로깅 추가
         System.out.println(channelPattern + channel);
         redisTemplate.convertAndSend(channelPattern + channel, message);
     }

--- a/web/src/main/java/com/example/web/service/RedisMessagePublisher.java
+++ b/web/src/main/java/com/example/web/service/RedisMessagePublisher.java
@@ -16,6 +16,7 @@ public class RedisMessagePublisher implements MessagePublisher {
 
     @Override
     public void publish(String channel, Object message) {
+        // TODO: 로깅 추가
         System.out.println(channelPattern + channel);
         redisTemplate.convertAndSend(channelPattern + channel, message);
     }

--- a/web/src/main/java/com/example/web/service/RoomService.java
+++ b/web/src/main/java/com/example/web/service/RoomService.java
@@ -53,7 +53,12 @@ public class RoomService {
         return new RoomVo(room.getId(), room.getType());
     }
 
-    public void deleteById(Integer roomId) {
-        roomRepository.deleteById(roomId);
+    public void softDeleteById(Integer roomId) {
+        roomRepository.findById(roomId).ifPresent(
+                room -> {
+                    room.setDeleted(true);
+                    roomRepository.save(room);
+                }
+        );
     }
 }

--- a/web/src/main/java/com/example/web/service/RoomService.java
+++ b/web/src/main/java/com/example/web/service/RoomService.java
@@ -52,4 +52,8 @@ public class RoomService {
     private RoomVo createRoomVo(Room room) {
         return new RoomVo(room.getId(), room.getType());
     }
+
+    public void deleteById(Integer roomId) {
+        roomRepository.deleteById(roomId);
+    }
 }

--- a/web/src/main/java/com/example/web/service/UserRoomService.java
+++ b/web/src/main/java/com/example/web/service/UserRoomService.java
@@ -73,4 +73,8 @@ public class UserRoomService {
     private UserRoomVo createUserRoomVo(UserRoom userRoom) {
         return new UserRoomVo(userRoom.getId(), userRoom.getNickname());
     }
+
+    public void deleteByRoomId(Integer roomId) {
+        userRoomRepository.deleteByRoomId(roomId);
+    }
 }

--- a/web/src/main/java/com/example/web/vo/EndRoomEventVo.java
+++ b/web/src/main/java/com/example/web/vo/EndRoomEventVo.java
@@ -1,0 +1,11 @@
+package com.example.web.vo;
+
+import com.example.web.enums.EventType;
+import lombok.Getter;
+
+@Getter
+public class EndRoomEventVo extends RoomEventVo {
+    public EndRoomEventVo(Integer roomId) {
+        super(EventType.END_ROOM, roomId);
+    }
+}

--- a/web/src/main/java/com/example/web/vo/MessageVo.java
+++ b/web/src/main/java/com/example/web/vo/MessageVo.java
@@ -1,21 +1,24 @@
 package com.example.web.vo;
 
+import com.example.web.enums.EventType;
 import com.example.web.enums.MessageType;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-@EqualsAndHashCode
-public class MessageVo {
-    private String id;
+public class MessageVo extends RoomEventVo {
+    private final String id;
 
-    private Integer roomId;
+    private final Integer userId;
 
-    private Integer userId;
+    private final MessageType type;
 
-    private MessageType type;
+    private final String content;
 
-    private String content;
+    public MessageVo(String id, Integer roomId, Integer userId, MessageType type, String content) {
+        super(EventType.MESSAGE, roomId);
+        this.id = id;
+        this.userId = userId;
+        this.type = type;
+        this.content = content;
+    }
 }

--- a/web/src/main/java/com/example/web/vo/MessageVo.java
+++ b/web/src/main/java/com/example/web/vo/MessageVo.java
@@ -1,24 +1,21 @@
 package com.example.web.vo;
 
-import com.example.web.enums.EventType;
 import com.example.web.enums.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-public class MessageVo extends RoomEventVo {
-    private final String id;
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MessageVo {
+    private String id;
 
-    private final Integer userId;
+    private Integer roomId;
 
-    private final MessageType type;
+    private Integer userId;
 
-    private final String content;
+    private MessageType type;
 
-    public MessageVo(String id, Integer roomId, Integer userId, MessageType type, String content) {
-        super(EventType.MESSAGE, roomId);
-        this.id = id;
-        this.userId = userId;
-        this.type = type;
-        this.content = content;
-    }
+    private String content;
 }

--- a/web/src/main/java/com/example/web/vo/RoomEventVo.java
+++ b/web/src/main/java/com/example/web/vo/RoomEventVo.java
@@ -1,0 +1,12 @@
+package com.example.web.vo;
+
+import com.example.web.enums.EventType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public abstract class RoomEventVo {
+    protected EventType eventType;
+    protected Integer roomId;
+}

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=web
 
+# JPA
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER_NAME}
 spring.datasource.password=${DB_USER_PASSWORD}
@@ -9,6 +10,7 @@ spring.jpa.hibernate.ddl-auto=${DDL_AUTO}
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
-spring.data.mongodb.host=${MONGODB_HOST:localhost}
-spring.data.mongodb.port=${MONGODB_PORT:27017}
-spring.data.mongodb.database=${MONGODB_DATABASE:manitalk}
+# MONGO
+spring.data.mongodb.uri=${MONGODB_URL:mongodb://mongo1:27017,mongo2:27018/manitalk?replicaSet=rs0}
+logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
+logging.level.org.springframework.data.mongodb.core.MongoOperations=DEBUG

--- a/web/src/test/java/com/example/web/controller/GroupRoomControllerTest.java
+++ b/web/src/test/java/com/example/web/controller/GroupRoomControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -151,5 +152,29 @@ class GroupRoomControllerTest {
                 .userRoomId(userRoomId)
                 .nickname(nickname)
                 .build();
+    }
+
+    @Test
+    @DisplayName("그룹 채팅을 종료합니다.")
+    void end_group_room() throws Exception {
+
+        // given
+        EndGroupRoomRequest endGroupRoomRequest = new EndGroupRoomRequest(
+                roomId,
+                roomOwnerId
+        );
+
+        EndRoomResponse endRoomResponse = EndRoomResponse.builder()
+                .roomId(roomId)
+                .build();
+        when(groupRoomService.endGroupRoom(any(EndGroupRoomRequest.class))).thenReturn(endRoomResponse);
+
+        // when & then
+        mockMvc.perform(delete("/group/room")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(endGroupRoomRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(endRoomResponse))
+                );
     }
 }

--- a/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
@@ -63,4 +63,10 @@ public class FakeGroupRoomDetailRepository implements GroupRoomDetailRepository 
         return database.values().stream()
                 .anyMatch(ur -> ur.getId().equals(id));
     }
+
+    @Override
+    public boolean existsByIdAndRoomOwnerId(Integer roomId, Integer userId) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getRoom().getId().equals(roomId) && ur.getRoomOwnerId().equals(userId));
+    }
 }

--- a/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
@@ -26,6 +26,16 @@ public class FakeUserRoomRepository implements UserRoomRepository {
     }
 
     @Override
+    public void deleteByRoomId(Integer roomId) {
+        List<Integer> idsToRemove = database.entrySet().stream()
+                .filter(ur -> ur.getValue().getRoom().getId().equals(roomId))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        idsToRemove.forEach(database::remove);
+    }
+
+    @Override
     public <S extends UserRoom> S save(S entity) {
         Integer id = entity.getId();
         if (entity.getId() == null) {

--- a/web/src/test/java/com/example/web/service/MessageServiceTest.java
+++ b/web/src/test/java/com/example/web/service/MessageServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.lang.reflect.Field;
 
@@ -35,7 +36,7 @@ class MessageServiceTest {
     private UserRoomService userRoomService;
 
     @Mock
-    private MessagePublisher messagePublisher;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Mock
     private MessageRepository messageRepository;

--- a/web/src/test/java/com/example/web/service/MessageServiceTest.java
+++ b/web/src/test/java/com/example/web/service/MessageServiceTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 
 import java.lang.reflect.Field;
 
@@ -36,7 +35,7 @@ class MessageServiceTest {
     private UserRoomService userRoomService;
 
     @Mock
-    private ApplicationEventPublisher applicationEventPublisher;
+    private MessagePublisher messagePublisher;
 
     @Mock
     private MessageRepository messageRepository;

--- a/websocket/src/main/resources/static/client.html
+++ b/websocket/src/main/resources/static/client.html
@@ -15,9 +15,16 @@
             stompClient = Stomp.over(socket);
             stompClient.connect({}, function (frame) {
                 console.log('Connected: ' + frame);
+
                 stompClient.subscribe('/room/' + roomId, function (message) {
-                    showMessage(message.body);
+                    var jsonMessage = JSON.parse(message.body);
+                    if (jsonMessage.eventType === 'MESSAGE') {
+                        showMessage(jsonMessage);
+                    } else {
+                        console.log(jsonMessage);
+                    }
                 });
+
                 document.getElementById("connect").style.display = "none";
                 document.getElementById("disconnect").style.display = "block";
             });
@@ -33,8 +40,7 @@
         }
 
         function showMessage(message) {
-            var jsonMessage = JSON.parse(message);
-            var data = jsonMessage.content;
+            var data = message.content;
 
             var response = document.getElementById("response");
             var p = document.createElement("p");


### PR DESCRIPTION
<br/>

## 작업 내용 📝

( 관련 이슈 : resolved  #8 )

그룹 채팅방을 종료하면서 관련 데이터를 삭제하고, 삭제 이벤트를 redis에 publish하는 작업입니다.

- 트랜잭션 내부에서 MySQL 데이터 삭제, 이벤트 발행
- 트랜잭션 커밋 완료 후 이벤트 리스너 실행되며 redis에 메시지 publish
- redis에 publish 실패한다면 2번 retry 후 MongoDB의 failed_events 컬렉션에 저장
- (추후) 배치서버에서 해당 컬렉션의 변경을 감지하여(Change Streams) 재발행 처리

![마니톡_시스템디자인-페이지-8 drawio](https://github.com/f-lab-edu/manitalk/assets/31975535/3362fcfe-9670-4656-beef-5ecf3db1c1f9)

<br/>

![마니톡_시스템디자인-이벤트](https://github.com/f-lab-edu/manitalk/assets/31975535/763f2f19-09be-4159-beb2-e7c4c126e13c)

<br/>

## 테스트 ✓

[로컬 API 테스트]
```
curl --location --request DELETE 'http://127.0.0.1:8080/group/room' \
--header 'Content-Type: application/json' \
--data '{
    "roomId": 80,
    "roomOwnerId": 3
}'
```

[테스트 코드]
- Controller: GroupRoomControllerTest
- Service: GroupRoomServiceTest

<br/>
