### PR TITLE
[#8] 그룹 채팅방 종료

### DIFF
--- a/web/src/main/java/com/example/web/WebApplication.java
+++ b/web/src/main/java/com/example/web/WebApplication.java
@@ -6,10 +6,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableMongoAuditing
+@EnableRetry
+@EnableAsync
 @Import(PropertyConfig.class)
 public class WebApplication {
 

--- a/web/src/main/java/com/example/web/advice/GlobalExceptionHandler.java
+++ b/web/src/main/java/com/example/web/advice/GlobalExceptionHandler.java
@@ -1,11 +1,10 @@
 package com.example.web.advice;
 
 import com.example.web.exception.ErrorMsg;
-import com.example.web.exception.room.CanNotEnterRoomException;
-import com.example.web.exception.room.DuplicatedRoomException;
-import com.example.web.exception.room.DuplicatedUserRoomException;
-import com.example.web.exception.room.RoomNotFoundException;
+import com.example.web.exception.room.*;
 import com.example.web.exception.user.UserNotFoundException;
+import jakarta.transaction.TransactionalException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -38,13 +37,19 @@ public class GlobalExceptionHandler {
         return createResponse(e.getMessage(), HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(CanNotEnterRoomException.class)
-    public ResponseEntity<ErrorMsg> canNotEnterRoomException(CanNotEnterRoomException e) {
+    @ExceptionHandler({CanNotEnterRoomException.class, CanNotDeleteRoomException.class})
+    public ResponseEntity<ErrorMsg> canNotEnterRoomException(RuntimeException e) {
         return createResponse(e.getMessage(), HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler({DuplicatedUserRoomException.class, DuplicatedRoomException.class})
     public ResponseEntity<ErrorMsg> duplicatedUserRoomException(RuntimeException e) {
         return createResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler({TransactionalException.class, DataIntegrityViolationException.class})
+    public ResponseEntity<ErrorMsg> failTransactionalException(RuntimeException e) {
+        // TODO: 로깅 추가
+        return createResponse("데이터 처리에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/web/src/main/java/com/example/web/config/AsyncConfig.java
+++ b/web/src/main/java/com/example/web/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.example.web.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(3);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/web/src/main/java/com/example/web/config/JpaConfig.java
+++ b/web/src/main/java/com/example/web/config/JpaConfig.java
@@ -1,0 +1,16 @@
+package com.example.web.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.JpaTransactionManager;
+
+@Configuration
+public class JpaConfig {
+    @Primary
+    @Bean
+    public JpaTransactionManager transactionManager(EntityManagerFactory jpaEntityManagerFactory) {
+        return new JpaTransactionManager(jpaEntityManagerFactory);
+    }
+}

--- a/web/src/main/java/com/example/web/config/MongoConfig.java
+++ b/web/src/main/java/com/example/web/config/MongoConfig.java
@@ -7,8 +7,8 @@ import org.springframework.data.mongodb.MongoTransactionManager;
 
 @Configuration
 public class MongoConfig {
-    @Bean
-    public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+    @Bean(name = "mongoTransactionManager")
+    public MongoTransactionManager mongoTransactionManager(MongoDatabaseFactory dbFactory) {
         return new MongoTransactionManager(dbFactory);
     }
 }

--- a/web/src/main/java/com/example/web/controller/GroupRoomController.java
+++ b/web/src/main/java/com/example/web/controller/GroupRoomController.java
@@ -1,18 +1,12 @@
 package com.example.web.controller;
 
-import com.example.web.dto.CreateGroupRoomRequest;
-import com.example.web.dto.EnterGroupRoomRequest;
-import com.example.web.dto.EnterRoomResponse;
+import com.example.web.dto.*;
 import com.example.web.service.GroupRoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import com.example.web.dto.CreateGroupRoomResponse;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/group/room")
@@ -29,5 +23,10 @@ public class GroupRoomController {
     @PostMapping("/enter")
     public ResponseEntity<EnterRoomResponse> enterGroupRoom(@Valid @RequestBody EnterGroupRoomRequest dto) {
         return new ResponseEntity<>(groupRoomService.enterGroupRoom(dto), HttpStatus.OK);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<EndRoomResponse> endGroupRoom(@Valid @RequestBody EndGroupRoomRequest dto) {
+        return new ResponseEntity<>(groupRoomService.endGroupRoom(dto), HttpStatus.OK);
     }
 }

--- a/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
+++ b/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
@@ -52,6 +52,9 @@ public class GroupRoomDetail {
     @Column(nullable = false)
     private String enterCode;
 
+    @Setter
+    private boolean deleted = Boolean.FALSE;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
+++ b/web/src/main/java/com/example/web/domain/GroupRoomDetail.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -21,6 +22,7 @@ import java.util.List;
 @Table(name = "group_room_details")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted = false")
 public class GroupRoomDetail {
 
     @Id

--- a/web/src/main/java/com/example/web/domain/Room.java
+++ b/web/src/main/java/com/example/web/domain/Room.java
@@ -30,6 +30,9 @@ public class Room {
     @Column(length = 1, nullable = false)
     private RoomType type = RoomType.G;
 
+    @Setter
+    private boolean deleted = Boolean.FALSE;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/web/src/main/java/com/example/web/domain/Room.java
+++ b/web/src/main/java/com/example/web/domain/Room.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -20,6 +21,7 @@ import java.util.List;
 @Table(name = "rooms")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
+@SQLRestriction("deleted = false")
 public class Room {
 
     @Id

--- a/web/src/main/java/com/example/web/domain/UserRoom.java
+++ b/web/src/main/java/com/example/web/domain/UserRoom.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -37,6 +38,9 @@ public class UserRoom {
 
     @Column
     private String nickname;
+
+    @Setter
+    private boolean deleted = Boolean.FALSE;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)

--- a/web/src/main/java/com/example/web/domain/UserRoom.java
+++ b/web/src/main/java/com/example/web/domain/UserRoom.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @Table(name = "user_rooms")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
+@SQLRestriction("deleted = false")
 public class UserRoom {
 
     @Id

--- a/web/src/main/java/com/example/web/dto/EndGroupRoomRequest.java
+++ b/web/src/main/java/com/example/web/dto/EndGroupRoomRequest.java
@@ -1,0 +1,19 @@
+package com.example.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class EndGroupRoomRequest {
+
+    @NotNull
+    private Integer roomId;
+
+    @NotNull
+    private Integer roomOwnerId;
+}

--- a/web/src/main/java/com/example/web/dto/EndRoomResponse.java
+++ b/web/src/main/java/com/example/web/dto/EndRoomResponse.java
@@ -1,0 +1,10 @@
+package com.example.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EndRoomResponse {
+    private Integer roomId;
+}

--- a/web/src/main/java/com/example/web/enums/EventType.java
+++ b/web/src/main/java/com/example/web/enums/EventType.java
@@ -1,0 +1,12 @@
+package com.example.web.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EventType {
+    END_ROOM("채팅 종료");
+
+    private final String description;
+}

--- a/web/src/main/java/com/example/web/event/EndRoomEvent.java
+++ b/web/src/main/java/com/example/web/event/EndRoomEvent.java
@@ -1,0 +1,11 @@
+package com.example.web.event;
+
+import com.example.web.enums.EventType;
+import lombok.Getter;
+
+@Getter
+public class EndRoomEvent extends RoomEvent {
+    public EndRoomEvent(Integer roomId) {
+        super(EventType.END_ROOM, roomId);
+    }
+}

--- a/web/src/main/java/com/example/web/event/PublishEventListener.java
+++ b/web/src/main/java/com/example/web/event/PublishEventListener.java
@@ -1,0 +1,41 @@
+package com.example.web.event;
+
+import com.example.web.service.MessagePublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PublishEventListener {
+
+    private final MessagePublisher messagePublisher;
+
+    @Value("${room.channel.prefix}")
+    String channelPrefix;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    @Retryable(
+            backoff = @Backoff(delay = 1000),
+            recover = "failRoomEvent"
+    )
+    public void handleRoomEvent(RoomEvent roomEvent) {
+        messagePublisher.publish(
+                channelPrefix + "/" + roomEvent.getRoomId(),
+                roomEvent
+        );
+    }
+
+    @Recover
+    private void failRoomEvent(RoomEvent roomEvent) {
+        // TODO: 최종 실패 로깅 처리
+        System.out.println(roomEvent.roomId + " - 삭제 이벤트 전송 실패");
+    }
+}

--- a/web/src/main/java/com/example/web/event/RoomEvent.java
+++ b/web/src/main/java/com/example/web/event/RoomEvent.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public abstract class RoomEvent {
+public class RoomEvent {
     protected EventType eventType;
     protected Integer roomId;
 }

--- a/web/src/main/java/com/example/web/event/RoomEvent.java
+++ b/web/src/main/java/com/example/web/event/RoomEvent.java
@@ -1,0 +1,12 @@
+package com.example.web.event;
+
+import com.example.web.enums.EventType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public abstract class RoomEvent {
+    protected EventType eventType;
+    protected Integer roomId;
+}

--- a/web/src/main/java/com/example/web/exception/room/CanNotDeleteRoomException.java
+++ b/web/src/main/java/com/example/web/exception/room/CanNotDeleteRoomException.java
@@ -1,0 +1,14 @@
+package com.example.web.exception.room;
+
+/**
+ * 채팅방을 삭제할 수 없는 경우
+ */
+public class CanNotDeleteRoomException extends RuntimeException {
+    public CanNotDeleteRoomException(String message) {
+        super(message);
+    }
+
+    public CanNotDeleteRoomException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/web/src/main/java/com/example/web/repository/GroupRoomDetailRepository.java
+++ b/web/src/main/java/com/example/web/repository/GroupRoomDetailRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupRoomDetailRepository extends BaseRepository<GroupRoomDetail, Integer> {
+    boolean existsByIdAndRoomOwnerId(Integer roomId, Integer userId);
 }

--- a/web/src/main/java/com/example/web/repository/UserRoomRepository.java
+++ b/web/src/main/java/com/example/web/repository/UserRoomRepository.java
@@ -15,4 +15,6 @@ public interface UserRoomRepository extends BaseRepository<UserRoom, Integer> {
 
     @Query("SELECT ur.user.id FROM UserRoom ur where ur.room.id = :roomId")
     List<Integer> findUserIdsByRoomId(@Param("roomId") Integer roomId);
+
+    void deleteByRoomId(Integer roomId);
 }

--- a/web/src/main/java/com/example/web/repository/UserRoomRepository.java
+++ b/web/src/main/java/com/example/web/repository/UserRoomRepository.java
@@ -17,4 +17,6 @@ public interface UserRoomRepository extends BaseRepository<UserRoom, Integer> {
     List<Integer> findUserIdsByRoomId(@Param("roomId") Integer roomId);
 
     void deleteByRoomId(Integer roomId);
+
+    List<UserRoom> findByRoomId(Integer roomId);
 }

--- a/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
+++ b/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
@@ -49,7 +49,12 @@ public class GroupRoomDetailService {
         return groupRoomDetailRepository.existsByIdAndRoomOwnerId(roomId, userId);
     }
 
-    public void deleteByRoomId(Integer roomId) {
-        groupRoomDetailRepository.deleteById(roomId);
+    public void softDeleteByRoomId(Integer roomId) {
+        groupRoomDetailRepository.findById(roomId).ifPresent(
+                groupRoomDetail -> {
+                    groupRoomDetail.setDeleted(true);
+                    groupRoomDetailRepository.save(groupRoomDetail);
+                }
+        );
     }
 }

--- a/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
+++ b/web/src/main/java/com/example/web/service/GroupRoomDetailService.java
@@ -44,4 +44,12 @@ public class GroupRoomDetailService {
                 groupRoomDetail.getEnterCode()
         );
     }
+
+    public boolean isRoomOwner(Integer roomId, Integer userId) {
+        return groupRoomDetailRepository.existsByIdAndRoomOwnerId(roomId, userId);
+    }
+
+    public void deleteByRoomId(Integer roomId) {
+        groupRoomDetailRepository.deleteById(roomId);
+    }
 }

--- a/web/src/main/java/com/example/web/service/GroupRoomService.java
+++ b/web/src/main/java/com/example/web/service/GroupRoomService.java
@@ -104,10 +104,10 @@ public class GroupRoomService {
         }
 
         // 채팅방에 속한 유저 데이터를 삭제합니다.
-        userRoomService.deleteByRoomId(dto.getRoomId());
+        userRoomService.softDeleteByRoomId(dto.getRoomId());
 
         // 채팅방 데이터를 삭제합니다.
-        groupRoomDetailService.deleteByRoomId(dto.getRoomId());
+        groupRoomDetailService.softDeleteByRoomId(dto.getRoomId());
         roomService.softDeleteById(dto.getRoomId());
 
         // 데이터 삭제 성공 시의 종료 이벤트를 발행합니다.

--- a/web/src/main/java/com/example/web/service/RoomService.java
+++ b/web/src/main/java/com/example/web/service/RoomService.java
@@ -52,4 +52,13 @@ public class RoomService {
     private RoomVo createRoomVo(Room room) {
         return new RoomVo(room.getId(), room.getType());
     }
+
+    public void softDeleteById(Integer roomId) {
+        roomRepository.findById(roomId).ifPresent(
+                room -> {
+                    room.setDeleted(true);
+                    roomRepository.save(room);
+                }
+        );
+    }
 }

--- a/web/src/main/java/com/example/web/service/UserRoomService.java
+++ b/web/src/main/java/com/example/web/service/UserRoomService.java
@@ -74,7 +74,12 @@ public class UserRoomService {
         return new UserRoomVo(userRoom.getId(), userRoom.getNickname());
     }
 
-    public void deleteByRoomId(Integer roomId) {
-        userRoomRepository.deleteByRoomId(roomId);
+    public void softDeleteByRoomId(Integer roomId) {
+        userRoomRepository.findByRoomId(roomId).forEach(
+                userRoom -> {
+                    userRoom.setDeleted(true);
+                    userRoomRepository.save(userRoom);
+                }
+        );
     }
 }

--- a/web/src/main/java/com/example/web/service/UserRoomService.java
+++ b/web/src/main/java/com/example/web/service/UserRoomService.java
@@ -73,4 +73,8 @@ public class UserRoomService {
     private UserRoomVo createUserRoomVo(UserRoom userRoom) {
         return new UserRoomVo(userRoom.getId(), userRoom.getNickname());
     }
+
+    public void deleteByRoomId(Integer roomId) {
+        userRoomRepository.deleteByRoomId(roomId);
+    }
 }

--- a/web/src/test/java/com/example/web/controller/GroupRoomControllerTest.java
+++ b/web/src/test/java/com/example/web/controller/GroupRoomControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -151,5 +152,29 @@ class GroupRoomControllerTest {
                 .userRoomId(userRoomId)
                 .nickname(nickname)
                 .build();
+    }
+
+    @Test
+    @DisplayName("그룹 채팅을 종료합니다.")
+    void end_group_room() throws Exception {
+
+        // given
+        EndGroupRoomRequest endGroupRoomRequest = new EndGroupRoomRequest(
+                roomId,
+                roomOwnerId
+        );
+
+        EndRoomResponse endRoomResponse = EndRoomResponse.builder()
+                .roomId(roomId)
+                .build();
+        when(groupRoomService.endGroupRoom(any(EndGroupRoomRequest.class))).thenReturn(endRoomResponse);
+
+        // when & then
+        mockMvc.perform(delete("/group/room")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(endGroupRoomRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(endRoomResponse))
+                );
     }
 }

--- a/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
@@ -13,7 +13,8 @@ public class FakeGroupRoomDetailRepository implements GroupRoomDetailRepository 
 
     @Override
     public Optional<GroupRoomDetail> findById(Integer id) {
-        return Optional.ofNullable(database.get(id));
+        GroupRoomDetail entity = database.get(id);
+        return (entity != null && !entity.isDeleted()) ? Optional.of(entity) : Optional.empty();
     }
 
     @Override
@@ -38,12 +39,18 @@ public class FakeGroupRoomDetailRepository implements GroupRoomDetailRepository 
 
     @Override
     public void deleteById(Integer id) {
-        database.remove(id);
+        GroupRoomDetail entity = database.get(id);
+        if (entity != null && !entity.isDeleted()) {
+            entity.setDeleted(true);
+        }
     }
 
     @Override
     public void delete(GroupRoomDetail entity) {
-        database.remove(entity.getId());
+        GroupRoomDetail existingEntity = database.get(entity.getId());
+        if (existingEntity != null && !existingEntity.isDeleted()) {
+            existingEntity.setDeleted(true);
+        }
     }
 
     @Override
@@ -55,18 +62,19 @@ public class FakeGroupRoomDetailRepository implements GroupRoomDetailRepository 
 
     @Override
     public GroupRoomDetail getReferenceById(Integer id) {
-        return database.get(id);
+        GroupRoomDetail entity = database.get(id);
+        return (entity != null && !entity.isDeleted()) ? entity : null;
     }
 
     @Override
     public boolean existsById(Integer id) {
-        return database.values().stream()
-                .anyMatch(ur -> ur.getId().equals(id));
+        GroupRoomDetail entity = database.get(id);
+        return entity != null && !entity.isDeleted();
     }
 
     @Override
     public boolean existsByIdAndRoomOwnerId(Integer roomId, Integer userId) {
         return database.values().stream()
-                .anyMatch(ur -> ur.getRoom().getId().equals(roomId) && ur.getRoomOwnerId().equals(userId));
+                .anyMatch(grd -> !grd.isDeleted() && grd.getRoom().getId().equals(roomId) && grd.getRoomOwnerId().equals(userId));
     }
 }

--- a/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeGroupRoomDetailRepository.java
@@ -63,4 +63,10 @@ public class FakeGroupRoomDetailRepository implements GroupRoomDetailRepository 
         return database.values().stream()
                 .anyMatch(ur -> ur.getId().equals(id));
     }
+
+    @Override
+    public boolean existsByIdAndRoomOwnerId(Integer roomId, Integer userId) {
+        return database.values().stream()
+                .anyMatch(ur -> ur.getRoom().getId().equals(roomId) && ur.getRoomOwnerId().equals(userId));
+    }
 }

--- a/web/src/test/java/com/example/web/repository/fake/FakeRoomRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeRoomRepository.java
@@ -14,7 +14,8 @@ public class FakeRoomRepository implements RoomRepository {
 
     @Override
     public Optional<Room> findById(Integer id) {
-        return Optional.ofNullable(database.get(id));
+        Room entity = database.get(id);
+        return (entity != null && !entity.isDeleted()) ? Optional.of(entity) : Optional.empty();
     }
 
     @Override
@@ -39,12 +40,18 @@ public class FakeRoomRepository implements RoomRepository {
 
     @Override
     public void deleteById(Integer id) {
-        database.remove(id);
+        Room entity = database.get(id);
+        if (entity != null && !entity.isDeleted()) {
+            entity.setDeleted(true);
+        }
     }
 
     @Override
     public void delete(Room entity) {
-        database.remove(entity.getId());
+        Room existingEntity = database.get(entity.getId());
+        if (existingEntity != null && !existingEntity.isDeleted()) {
+            existingEntity.setDeleted(true);
+        }
     }
 
     @Override
@@ -56,18 +63,19 @@ public class FakeRoomRepository implements RoomRepository {
 
     @Override
     public Room getReferenceById(Integer id) {
-        return database.get(id);
+        Room entity = database.get(id);
+        return (entity != null && !entity.isDeleted()) ? entity : null;
     }
 
     @Override
     public boolean existsById(Integer id) {
-        return database.values().stream()
-                .anyMatch(ur -> ur.getId().equals(id));
+        Room entity = database.get(id);
+        return entity != null && !entity.isDeleted();
     }
 
     @Override
     public boolean existsByIdAndType(Integer id, RoomType type) {
         return database.values().stream()
-                .anyMatch(r -> r.getId().equals(id) && r.getType().equals(type));
+                .anyMatch(r -> !r.isDeleted() && r.getId().equals(id) && r.getType().equals(type));
     }
 }

--- a/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
@@ -88,4 +88,11 @@ public class FakeUserRoomRepository implements UserRoomRepository {
 
         idsToRemove.forEach(database::remove);
     }
+
+    @Override
+    public List<UserRoom> findByRoomId(Integer roomId) {
+        return database.values().stream()
+                .filter(ur -> ur.getRoom().getId().equals(roomId))
+                .collect(Collectors.toList());
+    }
 }

--- a/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
+++ b/web/src/test/java/com/example/web/repository/fake/FakeUserRoomRepository.java
@@ -78,4 +78,14 @@ public class FakeUserRoomRepository implements UserRoomRepository {
         return database.values().stream()
                 .anyMatch(ur -> ur.getUser().getId().equals(userId) && ur.getRoom().getId().equals(roomId));
     }
+
+    @Override
+    public void deleteByRoomId(Integer roomId) {
+        List<Integer> idsToRemove = database.entrySet().stream()
+                .filter(ur -> ur.getValue().getRoom().getId().equals(roomId))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        idsToRemove.forEach(database::remove);
+    }
 }


### PR DESCRIPTION
<br/>

## 작업 내용 📝

( 관련 이슈 : resolved  #8 )

그룹 채팅방을 종료하면서 관련 데이터를 삭제하고, 삭제 이벤트를 redis에 publish하는 작업입니다.

- 트랜잭션 내부에서 MySQL 데이터 삭제, 이벤트 발행
- 트랜잭션 커밋 완료 후 이벤트 리스너 실행되며 redis에 메시지 publish
- redis에 publish 실패한다면 추가 2번 retry 후 로깅 처리

![마니톡_시스템디자인-페이지-종료](https://github.com/f-lab-edu/manitalk/assets/31975535/c39034bc-cd3c-4b5d-a798-13c4e99e889e)

<br/>

## 테스트 ✓

[로컬 API 테스트]
```
curl --location --request DELETE 'http://127.0.0.1:8080/group/room' \
--header 'Content-Type: application/json' \
--data '{
    "roomId": 80,
    "roomOwnerId": 3
}'
```

[테스트 코드]
- Controller: GroupRoomControllerTest
- Service: GroupRoomServiceTest

<br/>
