### PR TITLE
[#25] redis 채널 구독 방식 변경

### DIFF
--- a/common/src/main/resources/application-common.properties
+++ b/common/src/main/resources/application-common.properties
@@ -11,4 +11,4 @@ logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
 logging.level.org.springframework.data.mongodb.core.MongoOperations=DEBUG
 
 redis.channel.pattern=manitalk:
-room.channel.prefix=room
+room.channel.prefix=room/

--- a/websocket/src/main/java/com/example/websocket/config/RedisConfig.java
+++ b/websocket/src/main/java/com/example/websocket/config/RedisConfig.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -57,11 +56,9 @@ public class RedisConfig {
     }
 
     @Bean
-    RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory,
-                                                                MessageListenerAdapter listenerAdapter) {
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
-        container.addMessageListener(listenerAdapter, new PatternTopic(channelPattern + "*"));
         return container;
     }
 

--- a/websocket/src/main/java/com/example/websocket/config/WebSocketConfig.java
+++ b/websocket/src/main/java/com/example/websocket/config/WebSocketConfig.java
@@ -18,6 +18,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setApplicationDestinationPrefixes("/app");
+        registry.setApplicationDestinationPrefixes("/app", "/room");
     }
 }

--- a/websocket/src/main/java/com/example/websocket/controller/WebSocketController.java
+++ b/websocket/src/main/java/com/example/websocket/controller/WebSocketController.java
@@ -1,0 +1,19 @@
+package com.example.websocket.controller;
+
+import com.example.websocket.service.RedisMessageSubscriber;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.messaging.simp.annotation.SubscribeMapping;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+
+@Controller
+@RequiredArgsConstructor
+public class WebSocketController {
+
+    private final RedisMessageSubscriber subscriber;
+
+    @SubscribeMapping("/{roomId}")
+    public void handleSubscription(@DestinationVariable Integer roomId) {
+        subscriber.subscribeRoomChannel(roomId);
+    }
+}

--- a/websocket/src/main/java/com/example/websocket/event/PublishEventListener.java
+++ b/websocket/src/main/java/com/example/websocket/event/PublishEventListener.java
@@ -20,7 +20,7 @@ public class PublishEventListener {
     private final MessagePublisher messagePublisher;
 
     @Value("${room.channel.prefix}")
-    String channelPrefix;
+    String roomChannelPrefix;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Retryable(
@@ -29,7 +29,7 @@ public class PublishEventListener {
     )
     public void handleRoomEndEvent(MessageEvent messageEvent) {
         messagePublisher.publish(
-                channelPrefix + "/" + messageEvent.getMessageVo().getRoomId(),
+                roomChannelPrefix + messageEvent.getMessageVo().getRoomId(),
                 messageEvent.getMessageVo()
         );
     }

--- a/websocket/src/main/java/com/example/websocket/service/RedisMessageSubscriber.java
+++ b/websocket/src/main/java/com/example/websocket/service/RedisMessageSubscriber.java
@@ -4,16 +4,37 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class RedisMessageSubscriber implements MessageListener {
 
     private final WebSocketMessageBroadcaster messageBroadcaster;
+    private final RedisMessageListenerContainer container;
+    private final Set<String> subscribedChannels = new HashSet<>();
 
     @Value("${redis.channel.pattern}")
     String channelPattern;
+
+    @Value("${room.channel.prefix}")
+    String roomChannelPrefix;
+
+    public void subscribeRoomChannel(Integer roomId) {
+        String fullChannel = channelPattern + roomChannelPrefix + roomId;
+        if (!subscribedChannels.contains(fullChannel)) {
+            // TODO: 로깅 작업을 추가합니다.
+            System.out.println("subscribe: " + channelPattern + roomChannelPrefix + roomId);
+
+            container.addMessageListener(this, new ChannelTopic(fullChannel));
+            subscribedChannels.add(fullChannel);
+        }
+    }
 
     @Override
     public void onMessage(Message message, byte[] pattern) {

--- a/websocket/src/main/resources/static/client.html
+++ b/websocket/src/main/resources/static/client.html
@@ -2,9 +2,27 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>WebSocket Client</title>
+    <title>Manitalk</title>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+        }
+        .hidden {
+            display: none;
+        }
+        .message-container {
+            border: 1px solid #ccc;
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 5px;
+        }
+        .channel-messages {
+            max-height: 200px;
+            overflow-y: auto;
+        }
+    </style>
     <script>
         var stompClient = null;
         var url = '/manitalk/ws';
@@ -12,31 +30,71 @@
         function connect() {
             var socket = new SockJS(url);
             stompClient = Stomp.over(socket);
-            var roomId = document.getElementById('channel-id').value;
 
             stompClient.connect({}, function (frame) {
                 console.log('Connected: ' + frame);
 
-                // 채팅방 구독
-                stompClient.subscribe('/room/' + roomId, function (message) {
-                    showMessage(message.body);
-                });
-                document.getElementById("connect").style.display = "none";
-                document.getElementById("disconnect").style.display = "block";
-                document.getElementById("message-box").style.display = "block";
+                document.getElementById("connect").classList.add("hidden");
+                document.getElementById("subscribe").classList.remove("hidden");
+                document.getElementById("disconnect").classList.remove("hidden");
+                document.getElementById("chatBox").classList.remove("hidden");
+                document.getElementById('user-id').value = '';
             });
         }
 
-        function send() {
-            var requestId = Math.random().toString(36).substr(2, 9);
+        function subscribe() {
             var roomId = document.getElementById('channel-id').value;
+            if (!document.getElementById("channel-" + roomId)) {
+                var channelDiv = document.createElement("div");
+                channelDiv.id = "channel-" + roomId;
+                channelDiv.classList.add("message-container");
+
+                var channelHeader = document.createElement("h4");
+                channelHeader.innerText = "채팅방 ID: " + roomId;
+                channelDiv.appendChild(channelHeader);
+
+                var channelMessages = document.createElement("div");
+                channelMessages.classList.add("channel-messages");
+                channelDiv.appendChild(channelMessages);
+
+                var messageInput = document.createElement("input");
+                messageInput.id = "message-" + roomId;
+                messageInput.placeholder = "메시지 입력";
+                channelDiv.appendChild(messageInput);
+
+                var sendButton = document.createElement("button");
+                sendButton.innerText = "Send";
+                sendButton.onclick = function () {
+                    send(roomId);
+                };
+                channelDiv.appendChild(sendButton);
+
+                document.getElementById("chatBox").appendChild(channelDiv);
+            }
+
+            stompClient.subscribe('/room/' + roomId, function (message) {
+                showMessage(roomId, message.body);
+            });
+
+            document.getElementById('channel-id').value = '';
+        }
+
+        function send(roomId) {
+            var requestId = Math.random().toString(36).substr(2, 9);
             var userId = document.getElementById('user-id').value;
-            var content = document.getElementById('message-1').value;
-            var message = JSON.stringify({'requestId': requestId, 'roomId': roomId, 'userId': userId, 'messageType': 'T', 'content': content});
+            var content = document.getElementById('message-' + roomId).value;
+            var message = JSON.stringify({
+                'requestId': requestId,
+                'roomId': roomId,
+                'userId': userId,
+                'messageType': 'T',
+                'content': content
+            });
 
             console.log(message);
 
             stompClient.send("/app/send", {}, message);
+            document.getElementById('message-' + roomId).value = '';
         }
 
         function disconnect() {
@@ -44,43 +102,46 @@
                 stompClient.disconnect();
             }
             console.log("Disconnected");
-            document.getElementById("connect").style.display = "block";
-            document.getElementById("disconnect").style.display = "none";
-            document.getElementById("message-box").style.display = "none";
+            document.getElementById("connect").classList.remove("hidden");
+            document.getElementById("subscribe").classList.add("hidden");
+            document.getElementById("disconnect").classList.add("hidden");
+
+            document.getElementById("chatBox").classList.add("hidden");
+            var responseDiv = document.getElementById("chatBox");
+            while (responseDiv.firstChild) {
+                responseDiv.removeChild(responseDiv.firstChild);
+            }
         }
 
-        function showMessage(message) {
+        function showMessage(roomId, message) {
             var jsonMessage = JSON.parse(message);
             var data = jsonMessage.content;
 
-            var response = document.getElementById("response");
+            var channelMessages = document.querySelector("#channel-" + roomId + " .channel-messages");
             var p = document.createElement("p");
             p.style.wordWrap = "break-word";
             p.appendChild(document.createTextNode(data));
-            response.appendChild(p);
+            channelMessages.appendChild(p);
         }
     </script>
 </head>
 <body>
-<h2>WebSocket Client</h2>
+<h2>* Manitalk *</h2>
 <div id="connect">
-    <label for="channel-id">채팅방 ID : </label><input id="channel-id">
-    <label for="user-id">사용자 ID : </label><input id="user-id">
+    <label for="user-id">사용자 ID: </label><input id="user-id">
     <button onclick="connect()">Connect</button>
 </div>
-<div id="disconnect" hidden="hidden">
+<div id="disconnect" class="hidden">
     <button onclick="disconnect()">Disconnect</button>
 </div>
 <br>
 <br>
-<br>
-<div id="message-box" hidden="hidden">
-    <label for="message-1">메시지 입력 : </label><input id="message-1">
-    <button onclick="send()">Send</button>
-    <br>
-    <br>
-    <h3>~ Messages ~</h3>
-    <div id="response"></div>
+<div id="subscribe" class="hidden">
+    <label for="channel-id">채팅방 ID: </label><input id="channel-id">
+    <button onclick="subscribe()">Subscribe</button>
 </div>
+<br>
+<br>
+<div id="chatBox"></div>
 </body>
 </html>


### PR DESCRIPTION
<br/>

## 작업 내용 📝

( 관련 이슈 : resolved  #25 )

[변경 전]
스프링 웹소켓 어플리케이션 실행 시 `/room/*` 패턴의 모든 redis 채널을 구독하던 방식

[변경 후]
웹소켓 서버에 연결된 클라이언트가 채팅방에 입장(구독)할 때 해당하는 `/room/{roomId}` redis 채널을 구독하는 방식

**: 최종적으로 다중 웹소켓서버 환경에서 자신에게 연결되어 있지 않은 채팅방의 메시지는 받지 않게 됨**

<br/>

## 테스트 ✓

WebsocketApplication 실행: 클라이언트 페이지 접속하여 채팅방 웹소켓 연결 후 메시지 수발신 확인
URL : http://localhost:8081/client.html

<br/>
