### PR TITLE
[#29] API 문서화 - Swagger

### DIFF
--- a/web/build.gradle
+++ b/web/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	implementation project(':common')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/web/src/main/java/com/example/web/config/SwaggerConfig.java
+++ b/web/src/main/java/com/example/web/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.example.web.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Manitalk API Documentation")
+                .description("마니톡 API 문서")
+                .version("1.0.0");
+    }
+}

--- a/web/src/main/java/com/example/web/controller/GroupRoomController.java
+++ b/web/src/main/java/com/example/web/controller/GroupRoomController.java
@@ -2,6 +2,8 @@ package com.example.web.controller;
 
 import com.example.web.dto.*;
 import com.example.web.service.GroupRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,20 +13,24 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/group/room")
 @RequiredArgsConstructor
+@Tag(name = "Group Room", description = "그룹 채팅방 API")
 public class GroupRoomController {
 
     private final GroupRoomService groupRoomService;
 
+    @Operation(summary = "그룹 채팅방 생성")
     @PostMapping
     public ResponseEntity<CreateGroupRoomResponse> createGroupRoom(@Valid @RequestBody CreateGroupRoomRequest dto) {
         return new ResponseEntity<>(groupRoomService.createGroupRoom(dto), HttpStatus.OK);
     }
 
+    @Operation(summary = "그룹 채팅방 입장")
     @PostMapping("/enter")
     public ResponseEntity<EnterRoomResponse> enterGroupRoom(@Valid @RequestBody EnterGroupRoomRequest dto) {
         return new ResponseEntity<>(groupRoomService.enterGroupRoom(dto), HttpStatus.OK);
     }
 
+    @Operation(summary = "그룹 채팅방 종료")
     @DeleteMapping
     public ResponseEntity<EndRoomResponse> endGroupRoom(@Valid @RequestBody EndGroupRoomRequest dto) {
         return new ResponseEntity<>(groupRoomService.endGroupRoom(dto), HttpStatus.OK);

--- a/web/src/main/java/com/example/web/controller/ManitoRoomController.java
+++ b/web/src/main/java/com/example/web/controller/ManitoRoomController.java
@@ -2,6 +2,8 @@ package com.example.web.controller;
 
 import com.example.web.dto.*;
 import com.example.web.service.ManitoRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,15 +16,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/manito/room")
 @RequiredArgsConstructor
+@Tag(name = "Manito Room", description = "마니또 채팅방 API")
 public class ManitoRoomController {
 
     private final ManitoRoomService manitoRoomService;
 
+    @Operation(summary = "마니또 채팅방 생성")
     @PostMapping
     public ResponseEntity<CreateManitoRoomResponse> createManitoRooms(@Valid @RequestBody CreateManitoRoomRequest dto) {
         return new ResponseEntity<>(manitoRoomService.createManitoRooms(dto), HttpStatus.OK);
     }
 
+    @Operation(summary = "마니또 채팅방 입장")
     @PostMapping("/enter")
     public ResponseEntity<EnterManitoRoomResponse> enterManitoRoom(@Valid @RequestBody EnterManitoRoomRequest dto) {
         return new ResponseEntity<>(manitoRoomService.enterManitoRoom(dto), HttpStatus.OK);

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.jpa.hibernate.ddl-auto=${DDL_AUTO}
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
+springdoc.swagger-ui.path=/manitalk-api-docs


### PR DESCRIPTION
<br/>

## 작업 내용 📝

( 관련 이슈 : resolved  #29 )

Swagger 적용을 위해 Spring-Doc 라이브러리를 추가하고,
현재 개발된 각 API에 설명을 추가한 작업입니다.

![image](https://github.com/user-attachments/assets/f580640b-cb8e-4a69-b166-dad703c2a828)


<br/>

## 테스트 ✓
로컬 환경에서 어플리케이션 실행 후 아래 url로 접속하여 확인 가능합니다.

`http://localhost:8080/manitalk-api-docs`

<br/>
